### PR TITLE
Replace links to old Bitbucket repo with GitHub

### DIFF
--- a/acoustid/web/pages/database.md
+++ b/acoustid/web/pages/database.md
@@ -2,8 +2,8 @@ Title: Database
 
 The AcoustID database includes user-submitted audio fingerprints, their mapping to
 MusicBrainz IDs and some supporting tables. It follows the [structure of the
-PostgreSQL database][sql] used by the AcoustID server. Each table is exported in a
-separate file with the tab-separated text format used by the 
+PostgreSQL database][db] used by the AcoustID server. Each table is exported in a
+separate file with the tab-separated text format used by the
 [`COPY` command][copy]. At the moment, there are no tools for importing the
 database dump, it has to be done manually.
 
@@ -27,6 +27,6 @@ Once you have the public key imported, you can verify the signature:
 [copy]: http://www.postgresql.org/docs/9.0/static/sql-copy.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 [pd]: http://creativecommons.org/licenses/publicdomain/
-[sql]: https://bitbucket.org/acoustid/acoustid-server/src/master/sql/CreateTables.sql
+[db]: https://github.com/acoustid/acoustid-server/blob/master/acoustid/tables.py
 [gpg]: http://www.gnupg.org/
 [pubkey]: http://data.acoustid.org/pubkey.txt

--- a/acoustid/web/pages/faq.md
+++ b/acoustid/web/pages/faq.md
@@ -45,5 +45,3 @@ you need an [application API key](/my-applications). You need to
 
 [oid]: http://openid.net/
 
-[code]: https://bitbucket.org/acoustid/acoustid-server/src/master/acoustid/website.py
-

--- a/acoustid/web/pages/server.md
+++ b/acoustid/web/pages/server.md
@@ -9,10 +9,10 @@ but there are plans to implement a custom special-purpose index server for
 more efficient searches.
 
 The source code is licensed under the [MIT License][mit]. You can dowload it
-from from [Bitbucket][bb].
+from from [GitHub][gh].
 
 [mit]: http://creativecommons.org/licenses/MIT/
-[bb]: https://bitbucket.org/acoustid/acoustid-server
+[gh]: https://github.com/acoustid/acoustid-server
 [gin]: http://developer.postgresql.org/pgdocs/postgres/gin.html
-[bb-index]: https://bitbucket.org/acoustid/acoustid-index
+[bb-index]: https://github.com/acoustid/acoustid-index
 

--- a/admin/dev/ansible/build_pg_acoustid.yml
+++ b/admin/dev/ansible/build_pg_acoustid.yml
@@ -1,5 +1,5 @@
 - git:
-    repo=https://bitbucket.org/acoustid/pg_acoustid.git
+    repo=https://github.com/acoustid/pg_acoustid.git
     dest=/tmp/pg_acoustid
   register: pg_acoustid_git
 


### PR DESCRIPTION
The documentation pages still link to source code in the old Bitbucket repo. The code there is rather old. Also some links are not even valid anymore.

Update the links to point to GitHub instead.