### PR TITLE
Fix circular foreign key constraint warning from SQLAlchemy 1.4

### DIFF
--- a/acoustid/tables.py
+++ b/acoustid/tables.py
@@ -52,7 +52,7 @@ account = Table(
     ),
     Column("lastlogin", DateTime(timezone=True)),
     Column("submission_count", Integer, nullable=False, server_default=sql.literal(0)),
-    Column("application_id", Integer, ForeignKey("application.id")),
+    Column("application_id", Integer, ForeignKey("application.id", use_alter=True)),
     Column("application_version", String),
     Column("created_from", INET),
     Column(


### PR DESCRIPTION
Cannot correctly sort tables; there are unresolvable cycles between tables "account, application", which is usually caused by mutually dependent foreign key constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the application's underlying database configuration to better support dynamic adjustments in data relationships. This improvement streamlines future system updates and ensures more robust handling of internal structures, contributing to overall stability and performance during maintenance and migrations. These enhancements provide a smoother background operation without affecting the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->