### PR TITLE
Sanitize submission metadata to prevent PostgreSQL JSONB errors

### DIFF
--- a/acoustid/api/v2/__init__.py
+++ b/acoustid/api/v2/__init__.py
@@ -37,7 +37,7 @@ from acoustid.data.fingerprint import (
     FingerprintSearcher,
     decode_fingerprint,
 )
-from acoustid.data.meta import lookup_meta
+from acoustid.data.meta import fix_meta, lookup_meta
 from acoustid.data.musicbrainz import lookup_metadata
 from acoustid.data.stats import update_lookup_counter, update_user_agent_counter
 from acoustid.data.submission import insert_submission, lookup_submission_status
@@ -1002,7 +1002,7 @@ class SubmitHandler(APIHandler):
                 }
                 meta_values = dict((n, p[n]) for n in self.meta_fields if p[n])
                 if any(meta_values.values()):
-                    values["meta"] = meta_values
+                    values["meta"] = fix_meta(meta_values)
                 if p["foreignid"]:
                     values["foreignid"] = p["foreignid"]
                 if (


### PR DESCRIPTION
## Summary
- Apply `fix_meta()` to sanitize metadata at submission time
- Null characters (`\u0000`) in metadata fields cause PostgreSQL to reject JSONB inserts
- The same sanitization was already applied during import, but the error occurs earlier at insert time

## Test plan
- [x] Verified `fix_meta()` correctly strips null characters
- [ ] Deploy and verify errors stop occurring