### PR TITLE
Add fpindex_changelog, a commit-ordered feed of fingerprint changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,12 @@ jobs:
     services:
 
       postgresql:
-        image: quay.io/acoustid/postgresql:master
+        # Same image and tag as docker-compose.yml, so CI, local dev and
+        # production all run the same PostgreSQL. This was
+        # quay.io/acoustid/postgresql:master, which is 12.3 -- EOL, and five
+        # majors behind production, so CI could neither catch version-dependent
+        # problems nor accept code that works everywhere it actually runs.
+        image: ghcr.io/acoustid/postgres:pg17.4-main-00c3a23
         ports:
           - 5432/tcp
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,6 @@ jobs:
     services:
 
       postgresql:
-        # Same image and tag as docker-compose.yml, so CI, local dev and
-        # production all run the same PostgreSQL. This was
-        # quay.io/acoustid/postgresql:master, which is 12.3 -- EOL, and five
-        # majors behind production, so CI could neither catch version-dependent
-        # problems nor accept code that works everywhere it actually runs.
         image: ghcr.io/acoustid/postgres:pg17.4-main-00c3a23
         ports:
           - 5432/tcp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,35 @@ jobs:
           PGPASSWORD: acoustid
           PGDATABASE: postgres
 
+      # The test suite builds its database with metadata.create_all, so nothing
+      # else here ever runs a migration. This uses the acoustid_app /
+      # acoustid_fingerprint / acoustid_ingest databases that create_db.sql
+      # already makes and that the tests never touch -- three separate
+      # databases, which is what alembic's multi-database setup expects and
+      # what the single acoustid_test database could not provide.
+      #
+      # No config file: acoustid.conf is gitignored, RawConfigParser ignores a
+      # path that is not there, and everything comes from the environment.
+      - name: Test database migrations
+        run: uv run alembic -c alembic.ini upgrade head
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ACOUSTID_DATABASE_APP_NAME: acoustid_app
+          ACOUSTID_DATABASE_APP_HOST: localhost
+          ACOUSTID_DATABASE_APP_PORT: ${{ job.services.postgresql.ports['5432'] }}
+          ACOUSTID_DATABASE_APP_USER: acoustid
+          ACOUSTID_DATABASE_APP_PASSWORD: acoustid
+          ACOUSTID_DATABASE_FINGERPRINT_NAME: acoustid_fingerprint
+          ACOUSTID_DATABASE_FINGERPRINT_HOST: localhost
+          ACOUSTID_DATABASE_FINGERPRINT_PORT: ${{ job.services.postgresql.ports['5432'] }}
+          ACOUSTID_DATABASE_FINGERPRINT_USER: acoustid
+          ACOUSTID_DATABASE_FINGERPRINT_PASSWORD: acoustid
+          ACOUSTID_DATABASE_INGEST_NAME: acoustid_ingest
+          ACOUSTID_DATABASE_INGEST_HOST: localhost
+          ACOUSTID_DATABASE_INGEST_PORT: ${{ job.services.postgresql.ports['5432'] }}
+          ACOUSTID_DATABASE_INGEST_USER: acoustid
+          ACOUSTID_DATABASE_INGEST_PASSWORD: acoustid
+
       - name: Run tests
         run: ./check.sh --test
         env:

--- a/acoustid/cron.py
+++ b/acoustid/cron.py
@@ -30,6 +30,10 @@ def create_schedule(script: Script) -> Scheduler:
     schedule.every().minute.do(run_task("update_all_lookup_stats"))
     schedule.every().hour.do(run_task("update_all_user_agent_stats"))
     schedule.every().day.at("00:10").do(run_task("update_stats"))
+    # Hourly rather than daily: the work is idempotent and nearly free, and a
+    # job that only gets one attempt a day turns a single missed run into a
+    # day of lost headroom.
+    schedule.every().hour.do(run_task("manage_fpindex_changelog"))
     return schedule
 
 

--- a/acoustid/scripts/fpindex_changelog.py
+++ b/acoustid/scripts/fpindex_changelog.py
@@ -155,12 +155,68 @@ def create_partitions(conn: Connection, today: datetime.date) -> None:
             continue
 
 
+def _record_last_deleted(conn: Connection, name: str) -> int | None:
+    """Watermark the highest row in a partition that is about to be dropped.
+
+    Returns the id recorded, or None if the partition was empty and there is
+    therefore nothing to say.
+
+    Done as one statement so the row read and the row written cannot disagree,
+    and guarded so the watermark only ever moves forward -- partitions are
+    dropped oldest first, but a retry after a failure could revisit them in any
+    order, and a watermark that went backwards would quietly re-authorise a
+    cursor that is no longer resumable.
+    """
+    return conn.execute(
+        sql.text(
+            f"""
+            INSERT INTO fpindex_meta (
+                singleton,
+                last_deleted_id,
+                last_deleted_created,
+                last_deleted_xid,
+                updated
+            )
+            SELECT true, id, created, xid, clock_timestamp()
+            FROM ONLY {name}
+            ORDER BY id DESC
+            LIMIT 1
+            ON CONFLICT (singleton) DO UPDATE SET
+                last_deleted_id = EXCLUDED.last_deleted_id,
+                last_deleted_created = EXCLUDED.last_deleted_created,
+                last_deleted_xid = EXCLUDED.last_deleted_xid,
+                updated = EXCLUDED.updated
+            WHERE fpindex_meta.last_deleted_id < EXCLUDED.last_deleted_id
+            RETURNING last_deleted_id
+            """
+        )
+    ).scalar_one_or_none()
+
+
 def drop_partitions(conn: Connection, today: datetime.date) -> None:
     cutoff = fpindex_changelog_add_months(
         fpindex_changelog_month(today), -RETENTION_MONTHS
     )
     for name, month in sorted(_existing_partitions(conn).items(), key=lambda kv: kv[1]):
         if month >= cutoff:
+            continue
+        try:
+            # Before the drop, and committed separately from it. If the drop
+            # then fails the watermark is merely conservative -- it claims rows
+            # are gone while they are still there, so a consumer sitting right
+            # on the boundary bootstraps once for nothing, and the next run
+            # drops the partition anyway. The other order has no such margin:
+            # the rows vanish, nothing records that they did, and a consumer
+            # reading `id > cursor` gets an empty result and concludes it is up
+            # to date.
+            last_deleted_id = _record_last_deleted(conn, name)
+        except SQLAlchemyError:
+            logger.exception(
+                "Failed to record the retention watermark for %s, so not "
+                "dropping it: losing the rows without recording that they went "
+                "is the one thing fpindex_meta exists to prevent",
+                name,
+            )
             continue
         try:
             # Dropping the partition detaches it too, so this is one lock
@@ -172,7 +228,19 @@ def drop_partitions(conn: Connection, today: datetime.date) -> None:
             # and the next run tries again.
             logger.exception("Failed to drop changelog partition %s", name)
             continue
-        logger.info("Dropped changelog partition %s", name)
+        if last_deleted_id is None:
+            # Empty partition, or -- and this should not happen, since drops go
+            # oldest first -- one whose rows were all below the watermark
+            # already.
+            logger.info(
+                "Dropped changelog partition %s; retention watermark unchanged", name
+            )
+        else:
+            logger.info(
+                "Dropped changelog partition %s; the log now resumes after id %d",
+                name,
+                last_deleted_id,
+            )
 
 
 def report_headroom(conn: Connection, today: datetime.date) -> int:

--- a/acoustid/scripts/fpindex_changelog.py
+++ b/acoustid/scripts/fpindex_changelog.py
@@ -3,15 +3,16 @@
 
 """Partition maintenance for fpindex_changelog.
 
-The changelog is range-partitioned by day. Two jobs keep it healthy and they
+The changelog is range-partitioned by month. Two jobs keep it healthy and they
 fail in opposite directions, so they are deliberately independent:
 
-  create ahead -- a row with no partition to land in would fail the INSERT, and
-                  that INSERT is a fingerprint submission. A DEFAULT partition
-                  backstops it so writes never fail, but a row landing there
-                  then blocks creating the dated partition that would have
-                  covered it, so the default partition being non-empty is the
-                  thing worth alerting on.
+  create ahead -- there is no DEFAULT partition (see acoustid.tables for why),
+                  so a row with no partition to land in fails the INSERT, which
+                  fails the importer's transaction. Nothing is lost -- the
+                  submission stays in pending_submission and retries -- but the
+                  import queue stops draining until a partition exists. A year
+                  of runway is kept in front of the current month, so this takes
+                  twelve months of unnoticed failure to reach.
 
   drop behind  -- retention. Dropping a whole partition keeps vacuum out of the
                   picture: rows are never updated or deleted, and partitions die
@@ -19,7 +20,7 @@ fail in opposite directions, so they are deliberately independent:
 
 Alert on HEADROOM, not on this job succeeding. A job that silently stops running
 is exactly the case the headroom is defending against, and a green run tells you
-nothing about tomorrow.
+nothing about next month.
 """
 
 import datetime
@@ -31,54 +32,59 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.exc import SQLAlchemyError
 
 from acoustid.script import Script
+from acoustid.tables import (
+    FPINDEX_CHANGELOG_CREATE_AHEAD_MONTHS,
+    fpindex_changelog_add_months,
+    fpindex_changelog_create_partition_sql,
+    fpindex_changelog_month,
+)
 
 logger = logging.getLogger(__name__)
 
 
 TABLE_NAME = "fpindex_changelog"
-DEFAULT_PARTITION = "fpindex_changelog_default"
 
-# Keep well ahead of any plausible outage of this job.
-CREATE_AHEAD_DAYS = 30
+# Whole months to keep behind the current one, so between RETENTION_MONTHS and
+# RETENTION_MONTHS + 1 months of log are on disk at any moment.
+#
+# This is how far back a consumer may resume from the log alone. Falling off the
+# end is recoverable -- the node bootstraps from a peer snapshot instead -- so it
+# is a tuning knob, not a correctness boundary. Keep it well past the point where
+# a peer's own checkpoint would be too stale to donate. Note that the binding
+# constraint is bytes, not rows: `query` holds an extracted query array, so a
+# month is far larger on disk than its ~400k rows suggest.
+RETENTION_MONTHS = 2
 
-# How far back a consumer may resume from the log alone. Falling off the end is
-# recoverable -- the node bootstraps from a peer snapshot instead -- so this is
-# a tuning knob, not a correctness boundary. Keep it well past the point where
-# a peer's own checkpoint would be too stale to donate.
-RETENTION_DAYS = 14
-
+# Applied to the whole maintenance connection, not just to the drops.
+#
 # Measured on PG 17.4, not assumed: DROP TABLE <partition> and
 # ALTER TABLE ... DETACH PARTITION take exactly the same locks -- ACCESS
-# EXCLUSIVE on BOTH the parent and the partition. So this waits for every
-# transaction currently touching fpindex_changelog, and while it waits it queues
-# new readers behind it.
+# EXCLUSIVE on BOTH the parent and the partition. Creating a partition that does
+# not exist yet takes ACCESS EXCLUSIVE on the parent as well. Each of those waits
+# for every transaction currently touching fpindex_changelog, and while it waits
+# it queues new writers behind it -- and the writers here are the trigger, which
+# means fingerprint inserts stall for as long as the wait lasts.
 #
-# It is NOT enough that the partition is old and nobody wants its rows: opening
-# a partitioned table locks ALL partitions at plan time, before pruning runs, so
-# a consumer reading only today's data still holds ACCESS SHARE on a partition
-# from a fortnight ago. Adding a `created` predicate does not help; this was
-# tested. (Unrelated idle-in-transaction sessions that never touched the table
-# do not block it.)
+# It is NOT enough that a partition is old and nobody wants its rows: opening a
+# partitioned table locks ALL partitions at plan time, before pruning runs, so a
+# consumer reading only this month's data still holds ACCESS SHARE on a partition
+# from last year. Adding a `created` predicate does not help; this was tested.
+# (Unrelated idle-in-transaction sessions that never touched the table do not
+# block it.)
 #
 # What that means for the feed: a consumer must not hold a transaction open
 # across a long-poll wait. Query, end the transaction, wait outside it, query
-# again -- then the lock is held for milliseconds and an hourly retry finds a
-# gap immediately. Hold it for a 20s poll window and every drop attempt collides.
+# again -- then the lock is held for milliseconds and an hourly retry finds a gap
+# immediately. Hold it for a 20s poll window and every attempt collides.
 #
 # Hence a short timeout: give up rather than stall the feed, and try again next
-# hour. DETACH PARTITION ... CONCURRENTLY would take a weaker lock on the
-# parent, but PostgreSQL refuses it outright while a DEFAULT partition exists,
-# and the default partition is worth more -- without it a create-ahead job that
-# fell behind would fail INSERTs, and those INSERTs are fingerprint submissions.
-# Partitions piling up is slow, visible and recoverable; failing submissions is
-# an outage.
-DROP_LOCK_TIMEOUT = "1s"
+# hour. In the steady state this costs nothing anyway -- the no-op
+# CREATE TABLE IF NOT EXISTS calls, which is all but one of them a month, do not
+# take the parent lock at all, because PostgreSQL checks for the relation before
+# it locks.
+LOCK_TIMEOUT = "1s"
 
-_PARTITION_NAME_RE = re.compile(r"^fpindex_changelog_(\d{8})$")
-
-
-def _partition_name(day: datetime.date) -> str:
-    return "fpindex_changelog_" + day.strftime("%Y%m%d")
+_PARTITION_NAME_RE = re.compile(r"^fpindex_changelog_(\d{6})$")
 
 
 def _server_today(conn: Connection) -> datetime.date:
@@ -91,7 +97,7 @@ def _server_today(conn: Connection) -> datetime.date:
 
 
 def _existing_partitions(conn: Connection) -> dict[str, datetime.date]:
-    """Dated partitions of the changelog, by name.
+    """Monthly partitions of the changelog, by name.
 
     Only names matching the convention are returned, so nothing this job did
     not create can be dropped by it.
@@ -102,8 +108,7 @@ def _existing_partitions(conn: Connection) -> dict[str, datetime.date]:
             SELECT c.relname
             FROM pg_inherits i
             JOIN pg_class c ON c.oid = i.inhrelid
-            JOIN pg_class p ON p.oid = i.inhparent
-            WHERE p.relname = :parent
+            WHERE i.inhparent = to_regclass(:parent)
             """
         ),
         {"parent": TABLE_NAME},
@@ -114,45 +119,50 @@ def _existing_partitions(conn: Connection) -> dict[str, datetime.date]:
         match = _PARTITION_NAME_RE.match(name)
         if match is None:
             continue
-        partitions[name] = datetime.datetime.strptime(match.group(1), "%Y%m%d").date()
+        partitions[name] = datetime.datetime.strptime(match.group(1), "%Y%m").date()
     return partitions
 
 
+def _consecutive_months(months: set[datetime.date], start: datetime.date) -> int:
+    """How many months run unbroken from `start`.
+
+    Counting partitions would not do. A gap is the whole failure mode, and a
+    gap in the middle of the runway deserves as much attention as a short one --
+    but it leaves the count looking healthy.
+    """
+    count = 0
+    month = start
+    while month in months:
+        count += 1
+        month = fpindex_changelog_add_months(month, 1)
+    return count
+
+
 def create_partitions(conn: Connection, today: datetime.date) -> None:
-    for offset in range(CREATE_AHEAD_DAYS + 1):
-        day = today + datetime.timedelta(days=offset)
-        name = _partition_name(day)
+    current = fpindex_changelog_month(today)
+    for offset in range(FPINDEX_CHANGELOG_CREATE_AHEAD_MONTHS + 1):
+        month = fpindex_changelog_add_months(current, offset)
         try:
-            conn.execute(
-                sql.text(
-                    f"CREATE TABLE IF NOT EXISTS {name} "
-                    f"PARTITION OF {TABLE_NAME} "
-                    f"FOR VALUES FROM (:start) TO (:end)"
-                ),
-                {"start": day, "end": day + datetime.timedelta(days=1)},
-            )
+            conn.execute(sql.text(fpindex_changelog_create_partition_sql(month)))
         except SQLAlchemyError:
-            # The usual cause is rows for this day sitting in the default
-            # partition: PostgreSQL scans it and refuses to create a partition
-            # that would have claimed them. They have to be moved by hand.
+            # Usually lock_timeout firing because something else is busy on the
+            # table. Carry on rather than returning: the months after this one
+            # are independent, and one that cannot be created right now should
+            # not cost the entire year of runway behind it.
             logger.exception(
-                "Failed to create changelog partition %s; "
-                "check whether %s holds rows for that day",
-                name,
-                DEFAULT_PARTITION,
+                "Failed to create changelog partition for %s", month.strftime("%Y-%m")
             )
-            return
+            continue
 
 
 def drop_partitions(conn: Connection, today: datetime.date) -> None:
-    cutoff = today - datetime.timedelta(days=RETENTION_DAYS)
-    for name, day in sorted(_existing_partitions(conn).items(), key=lambda kv: kv[1]):
-        # The partition covers [day, day + 1), so it is only entirely older
-        # than the cutoff once its upper bound has passed it.
-        if day + datetime.timedelta(days=1) > cutoff:
+    cutoff = fpindex_changelog_add_months(
+        fpindex_changelog_month(today), -RETENTION_MONTHS
+    )
+    for name, month in sorted(_existing_partitions(conn).items(), key=lambda kv: kv[1]):
+        if month >= cutoff:
             continue
         try:
-            conn.execute(sql.text(f"SET lock_timeout = '{DROP_LOCK_TIMEOUT}'"))
             # Dropping the partition detaches it too, so this is one lock
             # acquisition rather than two.
             conn.execute(sql.text(f"DROP TABLE {name}"))
@@ -162,32 +172,22 @@ def drop_partitions(conn: Connection, today: datetime.date) -> None:
             # and the next run tries again.
             logger.exception("Failed to drop changelog partition %s", name)
             continue
-        finally:
-            conn.execute(sql.text("SET lock_timeout = DEFAULT"))
         logger.info("Dropped changelog partition %s", name)
 
 
-def check_default_partition(conn: Connection) -> int:
-    """Rows that missed every dated partition. Should always be zero."""
-    count = conn.execute(
-        sql.text(f"SELECT count(*) FROM ONLY {DEFAULT_PARTITION}")
-    ).scalar_one()
-    if count:
-        logger.error(
-            "%s holds %d rows: create-ahead fell behind, and the dated "
-            "partitions covering them cannot be created until they are moved",
-            DEFAULT_PARTITION,
-            count,
-        )
-    return count
-
-
 def report_headroom(conn: Connection, today: datetime.date) -> int:
-    """Days of partitions in front of us. This is the number to alert on."""
-    partitions = _existing_partitions(conn)
-    future = [day for day in partitions.values() if day >= today]
-    headroom = len(future)
-    logger.info("Changelog partition headroom: %d days", headroom)
+    """Months of unbroken partitions from the current one. Alert on this."""
+    months = set(_existing_partitions(conn).values())
+    headroom = _consecutive_months(months, fpindex_changelog_month(today))
+    if headroom:
+        logger.info("Changelog partition headroom: %d months", headroom)
+    else:
+        # With no default partition to catch them, fingerprint inserts are
+        # failing right now.
+        logger.error(
+            "No changelog partition covers %s; fingerprint inserts are failing",
+            today.strftime("%Y-%m"),
+        )
     return headroom
 
 
@@ -198,8 +198,8 @@ def run_manage_fpindex_changelog(script: Script) -> None:
     # right now does not roll back the partitions that were just created, and
     # nothing here holds a transaction open across the whole run.
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(sql.text(f"SET lock_timeout = '{LOCK_TIMEOUT}'"))
         today = _server_today(conn)
         create_partitions(conn, today)
         drop_partitions(conn, today)
-        check_default_partition(conn)
         report_headroom(conn, today)

--- a/acoustid/scripts/fpindex_changelog.py
+++ b/acoustid/scripts/fpindex_changelog.py
@@ -1,0 +1,205 @@
+# Copyright (C) 2026 Lukas Lalinsky
+# Distributed under the MIT license, see the LICENSE file for details.
+
+"""Partition maintenance for fpindex_changelog.
+
+The changelog is range-partitioned by day. Two jobs keep it healthy and they
+fail in opposite directions, so they are deliberately independent:
+
+  create ahead -- a row with no partition to land in would fail the INSERT, and
+                  that INSERT is a fingerprint submission. A DEFAULT partition
+                  backstops it so writes never fail, but a row landing there
+                  then blocks creating the dated partition that would have
+                  covered it, so the default partition being non-empty is the
+                  thing worth alerting on.
+
+  drop behind  -- retention. Dropping a whole partition keeps vacuum out of the
+                  picture: rows are never updated or deleted, and partitions die
+                  long before they reach freeze age.
+
+Alert on HEADROOM, not on this job succeeding. A job that silently stops running
+is exactly the case the headroom is defending against, and a green run tells you
+nothing about tomorrow.
+"""
+
+import datetime
+import logging
+import re
+
+from sqlalchemy import sql
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import SQLAlchemyError
+
+from acoustid.script import Script
+
+logger = logging.getLogger(__name__)
+
+
+TABLE_NAME = "fpindex_changelog"
+DEFAULT_PARTITION = "fpindex_changelog_default"
+
+# Keep well ahead of any plausible outage of this job.
+CREATE_AHEAD_DAYS = 30
+
+# How far back a consumer may resume from the log alone. Falling off the end is
+# recoverable -- the node bootstraps from a peer snapshot instead -- so this is
+# a tuning knob, not a correctness boundary. Keep it well past the point where
+# a peer's own checkpoint would be too stale to donate.
+RETENTION_DAYS = 14
+
+# Measured on PG 17.4, not assumed: DROP TABLE <partition> and
+# ALTER TABLE ... DETACH PARTITION take exactly the same locks -- ACCESS
+# EXCLUSIVE on BOTH the parent and the partition. So this waits for every
+# transaction currently touching fpindex_changelog, and while it waits it queues
+# new readers behind it.
+#
+# It is NOT enough that the partition is old and nobody wants its rows: opening
+# a partitioned table locks ALL partitions at plan time, before pruning runs, so
+# a consumer reading only today's data still holds ACCESS SHARE on a partition
+# from a fortnight ago. Adding a `created` predicate does not help; this was
+# tested. (Unrelated idle-in-transaction sessions that never touched the table
+# do not block it.)
+#
+# What that means for the feed: a consumer must not hold a transaction open
+# across a long-poll wait. Query, end the transaction, wait outside it, query
+# again -- then the lock is held for milliseconds and an hourly retry finds a
+# gap immediately. Hold it for a 20s poll window and every drop attempt collides.
+#
+# Hence a short timeout: give up rather than stall the feed, and try again next
+# hour. DETACH PARTITION ... CONCURRENTLY would take a weaker lock on the
+# parent, but PostgreSQL refuses it outright while a DEFAULT partition exists,
+# and the default partition is worth more -- without it a create-ahead job that
+# fell behind would fail INSERTs, and those INSERTs are fingerprint submissions.
+# Partitions piling up is slow, visible and recoverable; failing submissions is
+# an outage.
+DROP_LOCK_TIMEOUT = "1s"
+
+_PARTITION_NAME_RE = re.compile(r"^fpindex_changelog_(\d{8})$")
+
+
+def _partition_name(day: datetime.date) -> str:
+    return "fpindex_changelog_" + day.strftime("%Y%m%d")
+
+
+def _server_today(conn: Connection) -> datetime.date:
+    """Use the server's clock, not this process's.
+
+    The partition key is clock_timestamp(), so the only calendar that matters
+    is the database's.
+    """
+    return conn.execute(sql.text("SELECT current_date")).scalar_one()
+
+
+def _existing_partitions(conn: Connection) -> dict[str, datetime.date]:
+    """Dated partitions of the changelog, by name.
+
+    Only names matching the convention are returned, so nothing this job did
+    not create can be dropped by it.
+    """
+    rows = conn.execute(
+        sql.text(
+            """
+            SELECT c.relname
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = :parent
+            """
+        ),
+        {"parent": TABLE_NAME},
+    ).scalars()
+
+    partitions = {}
+    for name in rows:
+        match = _PARTITION_NAME_RE.match(name)
+        if match is None:
+            continue
+        partitions[name] = datetime.datetime.strptime(match.group(1), "%Y%m%d").date()
+    return partitions
+
+
+def create_partitions(conn: Connection, today: datetime.date) -> None:
+    for offset in range(CREATE_AHEAD_DAYS + 1):
+        day = today + datetime.timedelta(days=offset)
+        name = _partition_name(day)
+        try:
+            conn.execute(
+                sql.text(
+                    f"CREATE TABLE IF NOT EXISTS {name} "
+                    f"PARTITION OF {TABLE_NAME} "
+                    f"FOR VALUES FROM (:start) TO (:end)"
+                ),
+                {"start": day, "end": day + datetime.timedelta(days=1)},
+            )
+        except SQLAlchemyError:
+            # The usual cause is rows for this day sitting in the default
+            # partition: PostgreSQL scans it and refuses to create a partition
+            # that would have claimed them. They have to be moved by hand.
+            logger.exception(
+                "Failed to create changelog partition %s; "
+                "check whether %s holds rows for that day",
+                name,
+                DEFAULT_PARTITION,
+            )
+            return
+
+
+def drop_partitions(conn: Connection, today: datetime.date) -> None:
+    cutoff = today - datetime.timedelta(days=RETENTION_DAYS)
+    for name, day in sorted(_existing_partitions(conn).items(), key=lambda kv: kv[1]):
+        # The partition covers [day, day + 1), so it is only entirely older
+        # than the cutoff once its upper bound has passed it.
+        if day + datetime.timedelta(days=1) > cutoff:
+            continue
+        try:
+            conn.execute(sql.text(f"SET lock_timeout = '{DROP_LOCK_TIMEOUT}'"))
+            # Dropping the partition detaches it too, so this is one lock
+            # acquisition rather than two.
+            conn.execute(sql.text(f"DROP TABLE {name}"))
+        except SQLAlchemyError:
+            # Almost always lock_timeout firing because something else is busy
+            # on the table. Harmless: the partition stays attached and readable,
+            # and the next run tries again.
+            logger.exception("Failed to drop changelog partition %s", name)
+            continue
+        finally:
+            conn.execute(sql.text("SET lock_timeout = DEFAULT"))
+        logger.info("Dropped changelog partition %s", name)
+
+
+def check_default_partition(conn: Connection) -> int:
+    """Rows that missed every dated partition. Should always be zero."""
+    count = conn.execute(
+        sql.text(f"SELECT count(*) FROM ONLY {DEFAULT_PARTITION}")
+    ).scalar_one()
+    if count:
+        logger.error(
+            "%s holds %d rows: create-ahead fell behind, and the dated "
+            "partitions covering them cannot be created until they are moved",
+            DEFAULT_PARTITION,
+            count,
+        )
+    return count
+
+
+def report_headroom(conn: Connection, today: datetime.date) -> int:
+    """Days of partitions in front of us. This is the number to alert on."""
+    partitions = _existing_partitions(conn)
+    future = [day for day in partitions.values() if day >= today]
+    headroom = len(future)
+    logger.info("Changelog partition headroom: %d days", headroom)
+    return headroom
+
+
+def run_manage_fpindex_changelog(script: Script) -> None:
+    engine = script.db_engines["fingerprint"]
+    # Its own autocommit connection rather than the shared session: each DDL
+    # statement should commit on its own, so a partition that cannot be dropped
+    # right now does not roll back the partitions that were just created, and
+    # nothing here holds a transaction open across the whole run.
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        today = _server_today(conn)
+        create_partitions(conn, today)
+        drop_partitions(conn, today)
+        check_default_partition(conn)
+        report_headroom(conn, today)

--- a/acoustid/tables.py
+++ b/acoustid/tables.py
@@ -455,6 +455,47 @@ fpindex_changelog = Table(
 )
 
 
+# What retention threw away, so a consumer can tell that it did.
+#
+# The changelog on its own cannot express this. A consumer tailing
+# `WHERE id > cursor` that has fallen behind the retention window gets back an
+# empty result -- exactly what it gets when it is up to date. Nothing in the log
+# distinguishes "no changes since your cursor" from "the changes since your
+# cursor were dropped a fortnight ago", and the second one silently produces an
+# index that is missing fingerprints forever.
+#
+# So retention records the highest row it removed before removing it. A consumer
+# at `cursor` is safe if and only if `cursor >= last_deleted_id`; below that the
+# ids in `(cursor, last_deleted_id]` are gone and it has to bootstrap from a peer
+# snapshot instead of from the log. No row at all means nothing has ever been
+# deleted and any cursor is still resumable.
+#
+# `last_deleted_created` and `last_deleted_xid` are carried for the same reason
+# the changelog carries them: diagnostics, and they keep a snapshot-horizon read
+# strategy possible without another migration.
+#
+# One row, enforced. This mirrors the changelog's own decision not to carry a
+# lineage dimension -- there is one stream, so there is one watermark. If a
+# per-index or per-generation dimension ever arrives, both tables gain it
+# together.
+fpindex_meta = Table(
+    "fpindex_meta",
+    metadata,
+    Column("singleton", Boolean, primary_key=True, server_default=sql.true()),
+    Column("last_deleted_id", BigInteger, nullable=False),
+    Column("last_deleted_created", DateTime(timezone=True), nullable=False),
+    Column("last_deleted_xid", XID8, nullable=False),
+    Column(
+        "updated",
+        DateTime(timezone=True),
+        server_default=sql.text("clock_timestamp()"),
+        nullable=False,
+    ),
+    CheckConstraint("singleton", name="fpindex_meta_singleton"),
+    info={"bind_key": "fingerprint"},
+)
+
+
 # There is deliberately no DEFAULT partition.
 #
 # A default partition looks like a safe backstop and is the opposite. Rows that

--- a/acoustid/tables.py
+++ b/acoustid/tables.py
@@ -1,3 +1,5 @@
+import datetime
+
 import sqlalchemy.event
 from sqlalchemy import (
     DDL,
@@ -21,6 +23,7 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB, UUID
+from sqlalchemy.engine import Connection
 from sqlalchemy.types import UserDefinedType
 
 metadata = MetaData(
@@ -405,6 +408,12 @@ FPINDEX_CHANGELOG_LOCK_KEY = 7723016524936704001
 # working on dates cannot be caught out by a change in write volume the way an
 # id-range one could.
 #
+# Monthly, not daily. At the current rate -- around 13.5k new fingerprints a
+# day -- a month is roughly 400k rows, which is a perfectly ordinary table, and
+# the create-ahead job only has real work to do twelve times a year instead of
+# 365. That matters more than it sounds: creating a partition takes ACCESS
+# EXCLUSIVE on the parent, which queues the trigger's own inserts behind it.
+#
 # `created` uses clock_timestamp(), NOT now(): now() is transaction start time,
 # so a long transaction would file its row under an earlier partition than its
 # id-neighbours and the retained rows would stop being a contiguous id range.
@@ -446,19 +455,60 @@ fpindex_changelog = Table(
 )
 
 
+# There is deliberately no DEFAULT partition.
+#
+# A default partition looks like a safe backstop and is the opposite. Rows that
+# land in it permanently block creating the dated partition that would have
+# covered them, retention can never reclaim them because it only drops dated
+# partitions, and writes keep succeeding the whole time, so nothing pages. The
+# failure it is meant to prevent -- an insert with nowhere to go -- is not
+# actually an outage here: insert_fingerprint() is only ever reached from the
+# importer, the submission is already durable in the ingest database, and
+# pending_submission is cleared in the same transaction that would fail. So the
+# row stays queued and retries. Loud and self-healing beats silent and
+# hand-repairable, and dropping the default partition also keeps
+# DETACH PARTITION ... CONCURRENTLY available if retention ever needs it.
+#
+# What it costs: the partitions have to actually be there. See
+# acoustid.scripts.fpindex_changelog.
+FPINDEX_CHANGELOG_CREATE_AHEAD_MONTHS = 12
+
+
+def fpindex_changelog_month(day: datetime.date) -> datetime.date:
+    """The partition a date belongs to, identified by its first day."""
+    return day.replace(day=1)
+
+
+def fpindex_changelog_add_months(month: datetime.date, count: int) -> datetime.date:
+    index = month.year * 12 + (month.month - 1) + count
+    return datetime.date(index // 12, index % 12 + 1, 1)
+
+
+def fpindex_changelog_partition_name(month: datetime.date) -> str:
+    return "fpindex_changelog_" + month.strftime("%Y%m")
+
+
+def fpindex_changelog_create_partition_sql(month: datetime.date) -> str:
+    """DDL for the partition covering `month`.
+
+    The bounds are formatted into the statement rather than bound as
+    parameters. Partition bounds are DDL, and the parameterised form only works
+    at all because psycopg2 binds client-side -- it would break the day
+    anything here moves to psycopg3 or asyncpg. The values come from date
+    arithmetic, never from input.
+    """
+    end = fpindex_changelog_add_months(month, 1)
+    return (
+        f"CREATE TABLE IF NOT EXISTS {fpindex_changelog_partition_name(month)} "
+        f"PARTITION OF fpindex_changelog "
+        f"FOR VALUES FROM ('{month.isoformat()}') TO ('{end.isoformat()}')"
+    )
+
+
 # Kept in sync by hand with the alembic migration that introduces it. Migrations
 # must not import this module -- they have to keep working as the models move --
 # so the DDL is written out twice on purpose.
-#
-# Attached to the metadata rather than to fpindex_changelog because the trigger
-# is created on `fingerprint`, and only a metadata-level hook is guaranteed to
-# run after every table exists. There is deliberately no foreign key from the
-# changelog to the fingerprint: it is a log, and an FK would both cost writes
-# and stand in the way of dropping partitions.
 FPINDEX_CHANGELOG_DDL = f"""
-CREATE TABLE IF NOT EXISTS fpindex_changelog_default
-    PARTITION OF fpindex_changelog DEFAULT;
-
 CREATE OR REPLACE FUNCTION fpindex_changelog_insert() RETURNS trigger AS $$
 BEGIN
     PERFORM pg_advisory_xact_lock({FPINDEX_CHANGELOG_LOCK_KEY});
@@ -476,11 +526,38 @@ CREATE TRIGGER fingerprint_fpindex_changelog
     EXECUTE FUNCTION fpindex_changelog_insert();
 """
 
-sqlalchemy.event.listen(
-    metadata,
-    "after_create",
-    DDL(FPINDEX_CHANGELOG_DDL),
-)
+
+def _create_fpindex_changelog(
+    target: MetaData, connection: Connection, **kw: object
+) -> None:
+    """Partitions first, then the trigger.
+
+    Attached to the metadata rather than to fpindex_changelog because the
+    trigger is created on `fingerprint`, and only a metadata-level hook is
+    guaranteed to run after every table exists. There is deliberately no
+    foreign key from the changelog to the fingerprint: it is a log, and an FK
+    would both cost writes and stand in the way of dropping partitions.
+
+    The partitions matter here specifically because there is no DEFAULT to
+    catch a row that misses: create_all builds dev and test databases, where
+    nothing runs the hourly maintenance task, so without this the first
+    fingerprint insert would fail. The server's calendar is used, not this
+    process's, for the same reason the maintenance task uses it.
+    """
+    today = connection.execute(sql.text("SELECT current_date")).scalar_one()
+    month = fpindex_changelog_month(today)
+    for offset in range(FPINDEX_CHANGELOG_CREATE_AHEAD_MONTHS + 1):
+        connection.execute(
+            DDL(
+                fpindex_changelog_create_partition_sql(
+                    fpindex_changelog_add_months(month, offset)
+                )
+            )
+        )
+    connection.execute(DDL(FPINDEX_CHANGELOG_DDL))
+
+
+sqlalchemy.event.listen(metadata, "after_create", _create_fpindex_changelog)
 
 
 track_mbid = Table(

--- a/acoustid/tables.py
+++ b/acoustid/tables.py
@@ -1,6 +1,7 @@
 import sqlalchemy.event
 from sqlalchemy import (
     DDL,
+    BigInteger,
     Boolean,
     CheckConstraint,
     Column,
@@ -11,6 +12,8 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     MetaData,
+    PrimaryKeyConstraint,
+    Sequence,
     SmallInteger,
     String,
     Table,
@@ -18,6 +21,7 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB, UUID
+from sqlalchemy.types import UserDefinedType
 
 metadata = MetaData(
     naming_convention={
@@ -367,6 +371,117 @@ fingerprint_source = Table(
     Index("fingerprint_source_idx_submission_id", "submission_id"),
     info={"bind_key": "ingest"},
 )
+
+
+class XID8(UserDefinedType):
+    """PostgreSQL xid8 -- a transaction ID that does not wrap around.
+
+    Unlike the 32-bit xmin system column, xid8 carries the epoch, so values
+    stay comparable for the lifetime of the cluster.
+    """
+
+    cache_ok = True
+
+    def get_col_spec(self, **kw: object) -> str:
+        return "xid8"
+
+
+# Every writer serialises on this key inside fpindex_changelog_insert(), which
+# is what makes the changelog id order equal to the commit order. The value is
+# arbitrary but must never change: two different values are two different locks
+# and would silently stop serialising writers against each other.
+FPINDEX_CHANGELOG_LOCK_KEY = 7723016524936704001
+
+# Changes to the fingerprint table, in commit order, for fpindex to replay.
+#
+# `id` is the consumer cursor: a consumer tails `WHERE id > cursor ORDER BY id`
+# and that is safe ONLY because the trigger takes an advisory lock before the id
+# is allocated (see fpindex_changelog_insert below). Without it a transaction
+# that grabbed a lower id but committed later would be skipped forever, which is
+# the bug in the old index updater.
+#
+# Partitioned by `created` so retention is a calendar job: dropping whole
+# partitions keeps vacuum out of the picture entirely, and a create-ahead job
+# working on dates cannot be caught out by a change in write volume the way an
+# id-range one could.
+#
+# `created` uses clock_timestamp(), NOT now(): now() is transaction start time,
+# so a long transaction would file its row under an earlier partition than its
+# id-neighbours and the retained rows would stop being a contiguous id range.
+# Taken inside the advisory lock, clock_timestamp() advances in the same order
+# as the id, so time partitions and an id cursor agree.
+fpindex_changelog = Table(
+    "fpindex_changelog",
+    metadata,
+    Column(
+        "id",
+        BigInteger,
+        Sequence("fpindex_changelog_id_seq", metadata=metadata),
+        server_default=sql.text("nextval('fpindex_changelog_id_seq')"),
+        nullable=False,
+    ),
+    Column("fingerprint_id", Integer, nullable=False),
+    Column("query", ARRAY(Integer), nullable=False),
+    # Diagnostic, and it keeps the xmin-horizon read strategy available without
+    # a migration if the advisory lock ever needs to come out.
+    Column(
+        "xid",
+        XID8,
+        server_default=sql.text("pg_current_xact_id()"),
+        nullable=False,
+    ),
+    Column(
+        "created",
+        DateTime(timezone=True),
+        server_default=sql.text("clock_timestamp()"),
+        nullable=False,
+    ),
+    # A partitioned table may only have a unique constraint that covers the
+    # partition key, so the primary key is the pair. `id` alone is still unique
+    # -- it comes from a sequence -- and leads the index, which is what the
+    # consumer's `id > cursor` scan needs.
+    PrimaryKeyConstraint("id", "created"),
+    postgresql_partition_by="RANGE (created)",
+    info={"bind_key": "fingerprint"},
+)
+
+
+# Kept in sync by hand with the alembic migration that introduces it. Migrations
+# must not import this module -- they have to keep working as the models move --
+# so the DDL is written out twice on purpose.
+#
+# Attached to the metadata rather than to fpindex_changelog because the trigger
+# is created on `fingerprint`, and only a metadata-level hook is guaranteed to
+# run after every table exists. There is deliberately no foreign key from the
+# changelog to the fingerprint: it is a log, and an FK would both cost writes
+# and stand in the way of dropping partitions.
+FPINDEX_CHANGELOG_DDL = f"""
+CREATE TABLE IF NOT EXISTS fpindex_changelog_default
+    PARTITION OF fpindex_changelog DEFAULT;
+
+CREATE OR REPLACE FUNCTION fpindex_changelog_insert() RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock({FPINDEX_CHANGELOG_LOCK_KEY});
+    INSERT INTO fpindex_changelog (fingerprint_id, query)
+        VALUES (NEW.id, acoustid_extract_query(NEW.fingerprint));
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS fingerprint_fpindex_changelog ON fingerprint;
+
+CREATE TRIGGER fingerprint_fpindex_changelog
+    AFTER INSERT ON fingerprint
+    FOR EACH ROW
+    EXECUTE FUNCTION fpindex_changelog_insert();
+"""
+
+sqlalchemy.event.listen(
+    metadata,
+    "after_create",
+    DDL(FPINDEX_CHANGELOG_DDL),
+)
+
 
 track_mbid = Table(
     "track_mbid",

--- a/acoustid/worker.py
+++ b/acoustid/worker.py
@@ -10,6 +10,7 @@ import sentry_sdk
 import sentry_sdk.consts
 
 from acoustid.script import Script
+from acoustid.scripts.fpindex_changelog import run_manage_fpindex_changelog
 from acoustid.scripts.merge_missing_mbids import run_merge_missing_mbid
 from acoustid.scripts.update_lookup_stats import (
     run_update_all_lookup_stats,
@@ -35,6 +36,7 @@ TASKS: Dict[str, TaskFunc] = {
     "update_user_agent_stats": run_update_user_agent_stats,
     "update_all_user_agent_stats": run_update_all_user_agent_stats,
     "merge_missing_mbid": run_merge_missing_mbid,
+    "manage_fpindex_changelog": run_manage_fpindex_changelog,
 }
 
 

--- a/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
+++ b/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
@@ -1,0 +1,112 @@
+"""add fpindex_changelog
+
+Revision ID: a1f4c72b90de
+Revises: 8953fd9f151a
+Create Date: 2026-07-29 16:20:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1f4c72b90de"
+down_revision = "8953fd9f151a"
+branch_labels = None
+depends_on = None
+
+
+# Must match acoustid.tables.FPINDEX_CHANGELOG_LOCK_KEY. Migrations cannot
+# import the models -- they have to keep working as those move -- so the value
+# is repeated here on purpose. Changing it in one place only would leave two
+# different locks and silently stop serialising writers.
+LOCK_KEY = 7723016524936704001
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_app():
+    pass
+
+
+def downgrade_app():
+    pass
+
+
+def upgrade_ingest():
+    pass
+
+
+def downgrade_ingest():
+    pass
+
+
+def upgrade_fingerprint():
+    op.execute("CREATE SEQUENCE fpindex_changelog_id_seq AS bigint")
+    op.execute(
+        """
+        CREATE TABLE fpindex_changelog (
+            id bigint NOT NULL DEFAULT nextval('fpindex_changelog_id_seq'),
+            fingerprint_id integer NOT NULL,
+            query integer[] NOT NULL,
+            xid xid8 NOT NULL DEFAULT pg_current_xact_id(),
+            created timestamp with time zone NOT NULL DEFAULT clock_timestamp(),
+            CONSTRAINT fpindex_changelog_pkey PRIMARY KEY (id, created)
+        ) PARTITION BY RANGE (created)
+        """
+    )
+    op.execute("ALTER SEQUENCE fpindex_changelog_id_seq OWNED BY fpindex_changelog.id")
+
+    # Backstop so a create-ahead job that falls behind cannot fail writes. It
+    # should always be empty; alert if it is not, because a row landing here
+    # also blocks creating the dated partition that would have covered it.
+    op.execute(
+        """
+        CREATE TABLE fpindex_changelog_default
+            PARTITION OF fpindex_changelog DEFAULT
+        """
+    )
+
+    # The advisory lock is taken here, inside the trigger, rather than being
+    # documented as something callers must do. A requirement in prose is what
+    # produced the gaps in the old updater; taken here it covers every writer
+    # and cannot be forgotten. It is acquired before the changelog id is
+    # allocated and released at commit, so lock order == id order == commit
+    # order, which is what makes `WHERE id > cursor` safe for consumers.
+    #
+    # AFTER INSERT only. Not UPDATE: inc_fingerprint_submission_count updates
+    # submission_count on every duplicate submission and the fingerprint array
+    # itself never changes, so an UPDATE arm would be pure noise. Not DELETE:
+    # fingerprints are never deleted.
+    op.execute(
+        f"""
+        CREATE FUNCTION fpindex_changelog_insert() RETURNS trigger AS $$
+        BEGIN
+            PERFORM pg_advisory_xact_lock({LOCK_KEY});
+            INSERT INTO fpindex_changelog (fingerprint_id, query)
+                VALUES (NEW.id, acoustid_extract_query(NEW.fingerprint));
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER fingerprint_fpindex_changelog
+            AFTER INSERT ON fingerprint
+            FOR EACH ROW
+            EXECUTE FUNCTION fpindex_changelog_insert()
+        """
+    )
+
+
+def downgrade_fingerprint():
+    op.execute("DROP TRIGGER IF EXISTS fingerprint_fpindex_changelog ON fingerprint")
+    op.execute("DROP FUNCTION IF EXISTS fpindex_changelog_insert()")
+    op.execute("DROP TABLE IF EXISTS fpindex_changelog")
+    op.execute("DROP SEQUENCE IF EXISTS fpindex_changelog_id_seq")

--- a/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
+++ b/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
@@ -140,9 +140,27 @@ def upgrade_fingerprint():
         """
     )
 
+    # What retention threw away. Left empty on purpose: no row means nothing has
+    # ever been deleted, which is the truth on a fresh install, and it saves
+    # seeding the same row from both here and create_all. Retention upserts it.
+    op.execute(
+        """
+        CREATE TABLE fpindex_meta (
+            singleton boolean NOT NULL DEFAULT true,
+            last_deleted_id bigint NOT NULL,
+            last_deleted_created timestamp with time zone NOT NULL,
+            last_deleted_xid xid8 NOT NULL,
+            updated timestamp with time zone NOT NULL DEFAULT clock_timestamp(),
+            CONSTRAINT fpindex_meta_pkey PRIMARY KEY (singleton),
+            CONSTRAINT fpindex_meta_singleton CHECK (singleton)
+        )
+        """
+    )
+
 
 def downgrade_fingerprint():
     op.execute("DROP TRIGGER IF EXISTS fingerprint_fpindex_changelog ON fingerprint")
     op.execute("DROP FUNCTION IF EXISTS fpindex_changelog_insert()")
+    op.execute("DROP TABLE IF EXISTS fpindex_meta")
     op.execute("DROP TABLE IF EXISTS fpindex_changelog")
     op.execute("DROP SEQUENCE IF EXISTS fpindex_changelog_id_seq")

--- a/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
+++ b/alembic/versions/a1f4c72b90de_add_fpindex_changelog.py
@@ -21,6 +21,12 @@ depends_on = None
 # different locks and silently stop serialising writers.
 LOCK_KEY = 7723016524936704001
 
+# Must match acoustid.tables.FPINDEX_CHANGELOG_CREATE_AHEAD_MONTHS, for the same
+# reason and with the same caveat about not importing it. Drift here is benign
+# next to the lock key: the hourly task tops the runway back up, and headroom is
+# alerted on regardless.
+CREATE_AHEAD_MONTHS = 12
+
 
 def upgrade(engine_name):
     globals()["upgrade_%s" % engine_name]()
@@ -62,13 +68,43 @@ def upgrade_fingerprint():
     )
     op.execute("ALTER SEQUENCE fpindex_changelog_id_seq OWNED BY fpindex_changelog.id")
 
-    # Backstop so a create-ahead job that falls behind cannot fail writes. It
-    # should always be empty; alert if it is not, because a row landing here
-    # also blocks creating the dated partition that would have covered it.
+    # The current month plus a year of runway, created here rather than left to
+    # the hourly maintenance task.
+    #
+    # This has to happen in the same transaction as the trigger below. There is
+    # no DEFAULT partition -- see acoustid.tables for that argument -- so the
+    # moment the trigger exists, a fingerprint insert with no partition to land
+    # in fails. Waiting for the first cron run would leave that window open.
+    #
+    # Done in plpgsql, on the server, so the months come from the database's own
+    # calendar and timezone. That is the same calendar the maintenance task uses
+    # (`SELECT current_date`) and the same one the partition key is compared
+    # against, so the two cannot disagree about where a month begins. Keep the
+    # naming in step with acoustid.tables.fpindex_changelog_partition_name: the
+    # maintenance task recognises partitions by that pattern and ignores
+    # anything else, so a mismatch here would leave it reporting no headroom.
     op.execute(
-        """
-        CREATE TABLE fpindex_changelog_default
-            PARTITION OF fpindex_changelog DEFAULT
+        f"""
+        DO $$
+        DECLARE
+            start_month date := date_trunc('month', current_date)::date;
+            part_month date;
+            offset_months int;
+        BEGIN
+            FOR offset_months IN 0..{CREATE_AHEAD_MONTHS} LOOP
+                part_month := (
+                    start_month + (offset_months || ' months')::interval
+                )::date;
+                EXECUTE format(
+                    'CREATE TABLE %I PARTITION OF fpindex_changelog '
+                    'FOR VALUES FROM (%L) TO (%L)',
+                    'fpindex_changelog_' || to_char(part_month, 'YYYYMM'),
+                    part_month,
+                    (part_month + interval '1 month')::date
+                );
+            END LOOP;
+        END
+        $$
         """
     )
 

--- a/tests/test_fpindex_changelog.py
+++ b/tests/test_fpindex_changelog.py
@@ -2,14 +2,18 @@
 # Distributed under the MIT license, see the LICENSE file for details.
 
 import datetime
+import importlib.util
+import os
 
 import pytest
 from sqlalchemy import sql
 from sqlalchemy.exc import OperationalError
 
 import tests
+from acoustid import tables
 from acoustid.scripts.fpindex_changelog import (
     _existing_partitions,
+    _server_today,
     check_default_partition,
     create_partitions,
     drop_partitions,
@@ -171,11 +175,52 @@ def test_default_partition_is_reported_when_used(engine):
     """A row in the default partition means create-ahead fell behind. Writes
     still succeed -- that is the point of the backstop -- so this counter is
     the only thing that will tell anyone."""
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # The assertion below only means anything if nothing covers today:
+        # with a dated partition present the row lands there instead and the
+        # test would fail for a reason that has nothing to do with the backstop.
+        # Enforced rather than assumed, since any test that runs the real
+        # maintenance task would otherwise break this one confusingly.
+        today = _server_today(conn)
+        assert not [day for day in _existing_partitions(conn).values() if day == today]
+
     with engine.connect() as conn:
         conn.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
         conn.commit()
 
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-        # No dated partition covers today in the test database, so the row can
-        # only have landed in the default one.
         assert check_default_partition(conn) == 1
+
+
+# Path rather than an import: alembic versions are not a package, and a
+# migration must never import acoustid.tables anyway -- it has to keep working
+# as the models move, which is why the DDL is written out twice to begin with.
+MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "alembic",
+    "versions",
+    "a1f4c72b90de_add_fpindex_changelog.py",
+)
+
+
+def test_migration_and_models_agree_on_the_advisory_lock_key():
+    """The one duplication that fails silently and catastrophically.
+
+    The trigger DDL is deliberately written out twice -- once in tables.py for
+    create_all, once in the migration -- because a migration must not import the
+    models. Most drift between the two would surface as an obvious schema
+    mismatch. A divergent lock key would not: writers would take two *different*
+    advisory locks, stop serialising against each other, and the skipped-row gap
+    this whole changelog exists to close would quietly come back, with every
+    test still passing.
+    """
+    spec = importlib.util.spec_from_file_location("fpindex_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    assert migration.LOCK_KEY == tables.FPINDEX_CHANGELOG_LOCK_KEY
+    # And that the key each side actually emits is that constant, not a literal
+    # that drifted away from it.
+    assert str(tables.FPINDEX_CHANGELOG_LOCK_KEY) in tables.FPINDEX_CHANGELOG_DDL

--- a/tests/test_fpindex_changelog.py
+++ b/tests/test_fpindex_changelog.py
@@ -7,14 +7,15 @@ import os
 
 import pytest
 from sqlalchemy import sql
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DatabaseError, OperationalError
 
 import tests
 from acoustid import tables
 from acoustid.scripts.fpindex_changelog import (
+    RETENTION_MONTHS,
+    _consecutive_months,
     _existing_partitions,
     _server_today,
-    check_default_partition,
     create_partitions,
     drop_partitions,
     report_headroom,
@@ -121,9 +122,9 @@ def test_changelog_ids_and_timestamps_advance_together(engine):
     """created must be monotonic in id, or time partitions and an id cursor
     disagree and the retained rows stop being a contiguous id range.
 
-    This is why the trigger uses clock_timestamp() and not now(): now() is
-    transaction start time, so a slow transaction would file its row under an
-    earlier timestamp than rows with lower ids.
+    The sequential case only. now() would satisfy this one too -- see
+    test_created_follows_the_lock_not_the_transaction_start for the case that
+    actually separates the two.
     """
     with engine.connect() as conn:
         for seed in range(5):
@@ -141,55 +142,196 @@ def test_changelog_ids_and_timestamps_advance_together(engine):
     assert all(r.xid is not None for r in rows)
 
 
-def test_partitions_are_created_ahead_and_dropped_behind(engine):
-    """Exercised on a date far from today so it cannot collide with the
-    partitions a real deployment holds."""
-    today = datetime.date(2031, 6, 15)
+def test_created_follows_the_lock_not_the_transaction_start(engine):
+    """The case that distinguishes clock_timestamp() from now().
+
+    Staged so the writer that takes the *later* changelog id has the *earlier*
+    transaction start: `second` opens its transaction first, then `first` runs
+    and commits, then `second` inserts. With now() the second row would carry
+    the earlier timestamp despite the higher id -- and once created goes
+    backwards against id, the rows a partition holds are no longer a contiguous
+    id range, so retention would start cutting holes in the middle of the feed
+    rather than off its tail.
+    """
+    first = engine.connect()
+    second = engine.connect()
+    try:
+        # Opens second's transaction, fixing its now() before first inserts.
+        second.execute(sql.text("SELECT 1"))
+
+        first.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
+        first.commit()
+
+        second.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(2)})
+        second.commit()
+
+        rows = first.execute(
+            sql.text("SELECT id, created FROM fpindex_changelog ORDER BY id")
+        ).all()
+    finally:
+        first.close()
+        second.close()
+
+    assert len(rows) == 2
+    assert rows[0].created < rows[1].created
+
+
+def test_create_all_leaves_the_current_month_covered(engine):
+    """The database the rest of the suite runs against is built by create_all,
+    and with no DEFAULT partition every fingerprint insert in the whole suite
+    depends on that hook having created this month. Asserted directly, because
+    otherwise a break in it shows up as unrelated tests failing.
+
+    It also pins tables.py and the maintenance task to the same naming: the
+    task recognises partitions only by its own pattern, so a partition it
+    cannot see is a partition it will neither count nor drop.
+    """
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-        created_names = []
+        today = _server_today(conn)
+        name = tables.fpindex_changelog_partition_name(
+            tables.fpindex_changelog_month(today)
+        )
+        assert name in _existing_partitions(conn)
+        assert report_headroom(conn, today) >= 1
+
+
+def test_insert_fails_loudly_when_no_partition_covers_today(engine):
+    """The cost of having no DEFAULT partition, made explicit.
+
+    This is the trade: rather than silently absorbing the row and blocking the
+    partition that should have held it, the insert fails where someone will see
+    it. The importer's transaction rolls back, pending_submission is untouched,
+    and the submission retries once a partition exists.
+
+    Safe to assert because DDL is transactional in PostgreSQL -- the DROP is
+    rolled back with everything else, so the partition is still there
+    afterwards.
+    """
+    with engine.connect() as conn:
+        today = _server_today(conn)
+        name = tables.fpindex_changelog_partition_name(
+            tables.fpindex_changelog_month(today)
+        )
+        conn.execute(sql.text(f"DROP TABLE {name}"))
+        with pytest.raises(DatabaseError) as excinfo:
+            conn.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
+        assert "no partition of relation" in str(excinfo.value)
+        conn.rollback()
+
+    with engine.connect() as conn:
+        assert name in _existing_partitions(conn)
+
+
+def test_partitions_are_created_a_year_ahead(engine):
+    """Exercised on a date far from today so it cannot collide with the
+    partitions the test database actually needs."""
+    today = datetime.date(2031, 6, 15)
+    expected = ["fpindex_changelog_2031%02d" % month for month in range(6, 13)] + [
+        "fpindex_changelog_2032%02d" % month for month in range(1, 7)
+    ]
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         try:
             create_partitions(conn, today)
             partitions = _existing_partitions(conn)
-            created_names = [name for name, day in partitions.items() if day >= today]
 
-            assert partitions.get("fpindex_changelog_20310615") == today
-            assert report_headroom(conn, today) >= 30
-
-            # Nothing is old enough yet, so a drop pass must leave them alone.
-            drop_partitions(conn, today)
-            assert set(_existing_partitions(conn)) >= set(created_names)
-
-            # Far enough in the future that every partition just made has
-            # fallen entirely outside the retention window.
-            later = today + datetime.timedelta(days=365)
-            drop_partitions(conn, later)
-            remaining = set(_existing_partitions(conn))
-            assert not (remaining & set(created_names))
-            created_names = []
+            assert set(expected) <= set(partitions)
+            assert partitions["fpindex_changelog_203106"] == datetime.date(2031, 6, 1)
+            # A year of runway, counted as consecutive months rather than as a
+            # total, so a hole in the middle cannot pass for a full tank.
+            assert report_headroom(conn, today) == 13
         finally:
-            for name in created_names:
+            for name in expected:
                 conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
 
 
-def test_default_partition_is_reported_when_used(engine):
-    """A row in the default partition means create-ahead fell behind. Writes
-    still succeed -- that is the point of the backstop -- so this counter is
-    the only thing that will tell anyone."""
+def test_partitions_past_retention_are_dropped(engine):
+    """Run against the real current month, because the thing most likely to go
+    wrong with a cutoff is that it takes the live partition with it."""
+    old = [datetime.date(2020, 1, 1), datetime.date(2020, 2, 1)]
+    old_names = [tables.fpindex_changelog_partition_name(month) for month in old]
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-        # The assertion below only means anything if nothing covers today:
-        # with a dated partition present the row lands there instead and the
-        # test would fail for a reason that has nothing to do with the backstop.
-        # Enforced rather than assumed, since any test that runs the real
-        # maintenance task would otherwise break this one confusingly.
         today = _server_today(conn)
-        assert not [day for day in _existing_partitions(conn).values() if day == today]
+        current = tables.fpindex_changelog_partition_name(
+            tables.fpindex_changelog_month(today)
+        )
+        try:
+            for month in old:
+                conn.execute(
+                    sql.text(tables.fpindex_changelog_create_partition_sql(month))
+                )
+            assert set(old_names) <= set(_existing_partitions(conn))
 
-    with engine.connect() as conn:
-        conn.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
-        conn.commit()
+            drop_partitions(conn, today)
 
+            remaining = set(_existing_partitions(conn))
+            assert not (remaining & set(old_names))
+            assert current in remaining
+        finally:
+            for name in old_names:
+                conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_retention_keeps_whole_months_behind_the_current_one(engine):
+    """A partition is only dropped once its entire month is past the cutoff, so
+    the log always reaches back at least RETENTION_MONTHS."""
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-        assert check_default_partition(conn) == 1
+        today = _server_today(conn)
+        current = tables.fpindex_changelog_month(today)
+        boundary = tables.fpindex_changelog_add_months(current, -RETENTION_MONTHS)
+        names = [
+            tables.fpindex_changelog_partition_name(boundary),
+            tables.fpindex_changelog_partition_name(
+                tables.fpindex_changelog_add_months(boundary, -1)
+            ),
+        ]
+        try:
+            for name, month in zip(
+                names, [boundary, tables.fpindex_changelog_add_months(boundary, -1)]
+            ):
+                conn.execute(
+                    sql.text(tables.fpindex_changelog_create_partition_sql(month))
+                )
+
+            drop_partitions(conn, today)
+
+            remaining = set(_existing_partitions(conn))
+            # Exactly on the cutoff survives; one month older does not.
+            assert names[0] in remaining
+            assert names[1] not in remaining
+        finally:
+            for name in names:
+                conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_headroom_stops_at_the_first_gap():
+    """Pure, because the interesting case is hard to stage against a live
+    database without dropping a partition the rest of the suite needs.
+
+    A gap is the failure mode create_partitions is written to survive -- it
+    carries on past a month it could not create -- so headroom has to notice
+    one. A plain count of future partitions would not.
+    """
+    months = {
+        datetime.date(2026, 7, 1),
+        datetime.date(2026, 8, 1),
+        # September missing.
+        datetime.date(2026, 10, 1),
+        datetime.date(2026, 11, 1),
+    }
+    assert _consecutive_months(months, datetime.date(2026, 7, 1)) == 2
+    assert _consecutive_months(months, datetime.date(2026, 10, 1)) == 2
+    assert _consecutive_months(months, datetime.date(2026, 9, 1)) == 0
+
+
+def test_month_arithmetic_crosses_year_boundaries():
+    add_months = tables.fpindex_changelog_add_months
+    assert add_months(datetime.date(2026, 12, 1), 1) == datetime.date(2027, 1, 1)
+    assert add_months(datetime.date(2026, 1, 1), -1) == datetime.date(2025, 12, 1)
+    assert add_months(datetime.date(2026, 7, 1), 12) == datetime.date(2027, 7, 1)
+    assert add_months(datetime.date(2026, 7, 1), 0) == datetime.date(2026, 7, 1)
+    assert tables.fpindex_changelog_month(datetime.date(2026, 7, 31)) == datetime.date(
+        2026, 7, 1
+    )
 
 
 # Path rather than an import: alembic versions are not a package, and a

--- a/tests/test_fpindex_changelog.py
+++ b/tests/test_fpindex_changelog.py
@@ -15,6 +15,7 @@ from acoustid.scripts.fpindex_changelog import (
     RETENTION_MONTHS,
     _consecutive_months,
     _existing_partitions,
+    _record_last_deleted,
     _server_today,
     create_partitions,
     drop_partitions,
@@ -47,12 +48,49 @@ def engine():
     with engine.connect() as conn:
         conn.execute(sql.text("DELETE FROM fingerprint"))
         conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.execute(sql.text("DELETE FROM fpindex_meta"))
         conn.commit()
     yield engine
     with engine.connect() as conn:
         conn.execute(sql.text("DELETE FROM fingerprint"))
         conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.execute(sql.text("DELETE FROM fpindex_meta"))
         conn.commit()
+
+
+# Retention only touches partitions whose whole month is past the cutoff, so
+# anything staged for it has to be genuinely old. These bypass the trigger and
+# write straight to the changelog with an explicit `created`, which is the only
+# way to put a row in a month that has already been and gone.
+INSERT_OLD_CHANGELOG_ROW = """
+    INSERT INTO fpindex_changelog (fingerprint_id, query, created)
+    VALUES (:fingerprint_id, ARRAY[:fingerprint_id], :created)
+    RETURNING id
+"""
+
+
+def _stage_old_partition(conn, month, fingerprint_ids):
+    """Create a partition for `month` and fill it. Returns the row ids."""
+    conn.execute(sql.text(tables.fpindex_changelog_create_partition_sql(month)))
+    created = datetime.datetime(
+        month.year, month.month, 15, tzinfo=datetime.timezone.utc
+    )
+    return [
+        conn.execute(
+            sql.text(INSERT_OLD_CHANGELOG_ROW),
+            {"fingerprint_id": fingerprint_id, "created": created},
+        ).scalar_one()
+        for fingerprint_id in fingerprint_ids
+    ]
+
+
+def _watermark(conn):
+    return conn.execute(
+        sql.text(
+            "SELECT last_deleted_id, last_deleted_created, last_deleted_xid "
+            "FROM fpindex_meta"
+        )
+    ).one_or_none()
 
 
 def test_trigger_records_the_extracted_query(engine):
@@ -301,6 +339,143 @@ def test_retention_keeps_whole_months_behind_the_current_one(engine):
         finally:
             for name in names:
                 conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_retention_records_the_last_row_it_deleted(engine):
+    """Without this the log cannot distinguish "nothing changed since your
+    cursor" from "what changed since your cursor was dropped a fortnight ago".
+    Both answer `WHERE id > cursor` with zero rows.
+    """
+    month = datetime.date(2020, 3, 1)
+    name = tables.fpindex_changelog_partition_name(month)
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        try:
+            ids = _stage_old_partition(conn, month, [11, 22, 33])
+            assert _watermark(conn) is None
+
+            drop_partitions(conn, _server_today(conn))
+
+            mark = _watermark(conn)
+            assert mark is not None
+            # The highest id in the partition, not the first or an arbitrary
+            # one: everything at or below it is what a consumer can no longer
+            # reach.
+            assert mark.last_deleted_id == max(ids)
+            assert mark.last_deleted_created.date() == datetime.date(2020, 3, 15)
+            assert mark.last_deleted_xid is not None
+        finally:
+            conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_a_consumer_below_the_watermark_can_tell_it_has_fallen_off(engine):
+    """The whole point, stated as the consumer's check.
+
+    A cursor at or above the watermark is still resumable from the log alone.
+    Below it, the ids in between are gone and the consumer has to bootstrap
+    from a peer snapshot instead of quietly carrying on with a hole.
+    """
+    month = datetime.date(2020, 3, 1)
+    name = tables.fpindex_changelog_partition_name(month)
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        try:
+            ids = _stage_old_partition(conn, month, [11, 22, 33])
+            drop_partitions(conn, _server_today(conn))
+            last_deleted_id = _watermark(conn).last_deleted_id
+
+            # A consumer that had read everything before retention ran sits
+            # exactly on the watermark: nothing between its cursor and the
+            # start of the log was removed, so it may carry on.
+            assert ids[-1] >= last_deleted_id
+            # One that stopped in the middle of what was dropped may not, and
+            # the log itself would have told it nothing -- it is empty now.
+            stale_cursor = ids[0]
+            assert stale_cursor < last_deleted_id
+            assert (
+                conn.execute(
+                    sql.text(
+                        "SELECT count(*) FROM fpindex_changelog WHERE id > :cursor"
+                    ),
+                    {"cursor": stale_cursor},
+                ).scalar_one()
+                == 0
+            )
+        finally:
+            conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_watermark_never_moves_backwards(engine):
+    """Drops run oldest first, so this should not arise -- but a watermark that
+    could go backwards would re-authorise a cursor that is no longer resumable,
+    which is worse than never having recorded anything.
+    """
+    older, newer = datetime.date(2020, 1, 1), datetime.date(2020, 6, 1)
+    older_name, newer_name = (
+        tables.fpindex_changelog_partition_name(m) for m in (older, newer)
+    )
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        try:
+            # Staged in id order, so the older month holds the lower id. Both
+            # rows have to exist before either is recorded -- the sequence is
+            # global, so a row written into an old partition later still takes
+            # a higher id than one written into a newer partition earlier.
+            older_ids = _stage_old_partition(conn, older, [11])
+            newer_ids = _stage_old_partition(conn, newer, [22])
+            assert older_ids[0] < newer_ids[0]
+
+            # Record and remove the newer month first, out of the order the job
+            # would use, so the watermark is already ahead of what is left.
+            _record_last_deleted(conn, newer_name)
+            conn.execute(sql.text(f"DROP TABLE {newer_name}"))
+            assert _watermark(conn).last_deleted_id == newer_ids[0]
+
+            # Now the job reaches the older month, whose highest id is below
+            # the watermark. Dropping it is still correct; moving the watermark
+            # down to match it would not be.
+            drop_partitions(conn, _server_today(conn))
+
+            assert older_name not in _existing_partitions(conn)
+            assert _watermark(conn).last_deleted_id == newer_ids[0]
+        finally:
+            for name in (older_name, newer_name):
+                conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_dropping_an_empty_partition_records_nothing(engine):
+    """Nothing was lost, so there is nothing a consumer needs warning about."""
+    month = datetime.date(2020, 3, 1)
+    name = tables.fpindex_changelog_partition_name(month)
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        try:
+            conn.execute(sql.text(tables.fpindex_changelog_create_partition_sql(month)))
+
+            drop_partitions(conn, _server_today(conn))
+
+            assert name not in _existing_partitions(conn)
+            assert _watermark(conn) is None
+        finally:
+            conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_fpindex_meta_holds_at_most_one_row(engine):
+    """The watermark is a single value, and the schema says so rather than
+    trusting the job to only ever write one row."""
+    with engine.connect() as conn:
+        conn.execute(
+            sql.text(
+                "INSERT INTO fpindex_meta "
+                "(last_deleted_id, last_deleted_created, last_deleted_xid) "
+                "VALUES (1, now(), pg_current_xact_id())"
+            )
+        )
+        with pytest.raises(DatabaseError):
+            conn.execute(
+                sql.text(
+                    "INSERT INTO fpindex_meta (singleton, last_deleted_id, "
+                    "last_deleted_created, last_deleted_xid) "
+                    "VALUES (false, 2, now(), pg_current_xact_id())"
+                )
+            )
+        conn.rollback()
 
 
 def test_headroom_stops_at_the_first_gap():

--- a/tests/test_fpindex_changelog.py
+++ b/tests/test_fpindex_changelog.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2026 Lukas Lalinsky
+# Distributed under the MIT license, see the LICENSE file for details.
+
+import datetime
+
+import pytest
+from sqlalchemy import sql
+from sqlalchemy.exc import OperationalError
+
+import tests
+from acoustid.scripts.fpindex_changelog import (
+    _existing_partitions,
+    check_default_partition,
+    create_partitions,
+    drop_partitions,
+    report_headroom,
+)
+
+# SQLSTATE lock_not_available -- what lock_timeout raises when a statement gives
+# up waiting. Used here to observe blocking without threads or sleeps.
+LOCK_NOT_AVAILABLE = "55P03"
+
+
+INSERT_FINGERPRINT = """
+    INSERT INTO fingerprint (fingerprint, length, track_id, submission_count)
+    VALUES (:fingerprint, 100, 1, 1)
+    RETURNING id
+"""
+
+
+def _fingerprint(seed):
+    # type: (int) -> list[int]
+    # acoustid_extract_query drops duplicates and the silence hash, so the
+    # values have to actually differ for the extracted query to be non-empty.
+    return [seed * 1000 + i for i in range(200)]
+
+
+@pytest.fixture
+def engine():
+    assert tests.script is not None
+    engine = tests.script.db_engines["fingerprint"]
+    with engine.connect() as conn:
+        conn.execute(sql.text("DELETE FROM fingerprint"))
+        conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.commit()
+    yield engine
+    with engine.connect() as conn:
+        conn.execute(sql.text("DELETE FROM fingerprint"))
+        conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.commit()
+
+
+def test_trigger_records_the_extracted_query(engine):
+    """The log carries what the index is fed, not the raw fingerprint."""
+    hashes = _fingerprint(1)
+    with engine.connect() as conn:
+        fingerprint_id = conn.execute(
+            sql.text(INSERT_FINGERPRINT), {"fingerprint": hashes}
+        ).scalar_one()
+        conn.commit()
+
+        row = conn.execute(
+            sql.text("SELECT fingerprint_id, query FROM fpindex_changelog")
+        ).one()
+        expected = conn.execute(
+            sql.text("SELECT acoustid_extract_query(:fp)"), {"fp": hashes}
+        ).scalar_one()
+
+    assert row.fingerprint_id == fingerprint_id
+    assert row.query == expected
+    assert len(row.query) > 0
+    assert row.query != hashes
+
+
+def test_second_writer_blocks_until_the_first_commits(engine):
+    """The property the whole design rests on.
+
+    Without pg_advisory_xact_lock in the trigger this test fails: the second
+    writer would sail past, take a higher changelog id, and be free to commit
+    before the first one -- leaving a lower id that appears in the log only
+    after a consumer has already read past it, and is therefore skipped
+    forever. That is the bug in the old index updater.
+    """
+    first = engine.connect()
+    second = engine.connect()
+    try:
+        first.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
+        # Deliberately not committed: the advisory lock is held to end of
+        # transaction, so the second writer must not get through.
+
+        second.execute(sql.text("SET lock_timeout = '2s'"))
+        with pytest.raises(OperationalError) as excinfo:
+            second.execute(
+                sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(2)}
+            )
+        assert getattr(excinfo.value.orig, "pgcode", None) == LOCK_NOT_AVAILABLE
+
+        second.rollback()
+        first.commit()
+
+        # Once the lock is released the same insert goes through, and lands
+        # after the transaction that was holding it.
+        second.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(2)})
+        second.commit()
+
+        rows = first.execute(
+            sql.text("SELECT id, fingerprint_id FROM fpindex_changelog ORDER BY id")
+        ).all()
+        assert len(rows) == 2
+        assert rows[0].id < rows[1].id
+    finally:
+        first.close()
+        second.close()
+
+
+def test_changelog_ids_and_timestamps_advance_together(engine):
+    """created must be monotonic in id, or time partitions and an id cursor
+    disagree and the retained rows stop being a contiguous id range.
+
+    This is why the trigger uses clock_timestamp() and not now(): now() is
+    transaction start time, so a slow transaction would file its row under an
+    earlier timestamp than rows with lower ids.
+    """
+    with engine.connect() as conn:
+        for seed in range(5):
+            conn.execute(
+                sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(seed)}
+            )
+            conn.commit()
+
+        rows = conn.execute(
+            sql.text("SELECT id, created, xid FROM fpindex_changelog ORDER BY id")
+        ).all()
+
+    assert len(rows) == 5
+    assert [r.created for r in rows] == sorted(r.created for r in rows)
+    assert all(r.xid is not None for r in rows)
+
+
+def test_partitions_are_created_ahead_and_dropped_behind(engine):
+    """Exercised on a date far from today so it cannot collide with the
+    partitions a real deployment holds."""
+    today = datetime.date(2031, 6, 15)
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        created_names = []
+        try:
+            create_partitions(conn, today)
+            partitions = _existing_partitions(conn)
+            created_names = [name for name, day in partitions.items() if day >= today]
+
+            assert partitions.get("fpindex_changelog_20310615") == today
+            assert report_headroom(conn, today) >= 30
+
+            # Nothing is old enough yet, so a drop pass must leave them alone.
+            drop_partitions(conn, today)
+            assert set(_existing_partitions(conn)) >= set(created_names)
+
+            # Far enough in the future that every partition just made has
+            # fallen entirely outside the retention window.
+            later = today + datetime.timedelta(days=365)
+            drop_partitions(conn, later)
+            remaining = set(_existing_partitions(conn))
+            assert not (remaining & set(created_names))
+            created_names = []
+        finally:
+            for name in created_names:
+                conn.execute(sql.text(f"DROP TABLE IF EXISTS {name}"))
+
+
+def test_default_partition_is_reported_when_used(engine):
+    """A row in the default partition means create-ahead fell behind. Writes
+    still succeed -- that is the point of the backstop -- so this counter is
+    the only thing that will tell anyone."""
+    with engine.connect() as conn:
+        conn.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(1)})
+        conn.commit()
+
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # No dated partition covers today in the test database, so the row can
+        # only have landed in the default one.
+        assert check_default_partition(conn) == 1


### PR DESCRIPTION
Groundwork for feeding fpindex from a changelog instead of the current
`WHERE id > max_document_id` tail. Experimental — nothing consumes this yet.

## The problem

The index updater tails a sequence-allocated column. A transaction that takes a
lower id but commits later is skipped **permanently**: it will never satisfy
`id > cursor` again, and nothing detects it. Same shape as the timestamp-window
gap in the public data exports.

## The approach

An `AFTER INSERT` trigger on `fingerprint` writes a changelog row, taking
`pg_advisory_xact_lock` before the changelog id is allocated and holding it to
commit. Lock order equals id order equals commit order, so `WHERE id > cursor
ORDER BY id` is safe. PostgreSQL removes a transaction from the procarray before
releasing its locks, so "the next writer got the lock" implies "the previous one
is already visible", and no id can be allocated above an uncommitted one.

The lock is taken **in the trigger**, not documented as a requirement on
callers. A requirement in prose is what produced the gap in the first place; in
the trigger it covers every writer, including paths that don't exist yet.

`AFTER INSERT` only. Not UPDATE — `inc_fingerprint_submission_count` fires on
every duplicate submission and the fingerprint array itself never changes, so an
UPDATE arm would be pure noise. Not DELETE — fingerprints aren't deleted.

Rows carry the extracted query terms (what already reaches the index) plus
`pg_current_xact_id()`. The xid is a diagnostic, and it keeps a snapshot-horizon
read strategy available without a migration if the lock ever needs to come out.

Partitioned by month. Retention becomes a calendar job, and a create-ahead job
working on dates can't be caught out by a change in write volume the way an
id-range one could. Table, trigger and the first year of partitions live in the
migration; keeping the runway topped up is an hourly task, since partitions are
operational state rather than schema.

## Sizing

At ~13,500 new fingerprints a day a monthly partition holds roughly 400k rows.
Daily partitions were the original design and bought nothing at that rate, while
costing a real partition creation every day instead of twelve a year — which
matters, because creating one takes ACCESS EXCLUSIVE on the parent and the
trigger's own inserts queue behind it while it waits.

The same number retires a concern about the advisory lock: 13,500/day is 0.16
inserts a second, so a single global lock held for the tail of one importer
transaction never binds. Importer concurrency is capped at 1 by construction,
and at this volume that ceiling is three orders of magnitude away.

Note that retention is bounded by bytes rather than rows — `query` holds an
extracted query array, so a month is far larger on disk than 400k rows suggests.

## No DEFAULT partition

This is the part most worth arguing about, and it reverses an earlier decision
in this branch.

A default partition looks like a safe backstop and is the opposite. Rows that
land in it permanently block creating the dated partition that would have
covered them, retention can never reclaim them because it only drops dated
partitions, and writes keep succeeding the whole time, so nothing pages. You are
left hand-moving rows out of it.

The failure it guards against isn't an outage here. `insert_fingerprint()` is
only ever reached from the importer — nothing in `acoustid/api/` or
`acoustid/web/` imports inline. By then the submission is already durable in the
ingest database, and `pending_submission` is cleared in the same transaction
that would fail, so a missing partition rolls the batch back, leaves the row
queued, and retries. Nothing is lost; the import queue stops draining and says
so. `is_transient_import_error` doesn't recognise that error, so it reaches
Sentry on the first occurrence.

Loud and self-healing beats silent and hand-repairable. Dropping it also keeps
`DETACH PARTITION ... CONCURRENTLY` available, which a default partition makes
PostgreSQL refuse outright — not used today, since with no consumer there is no
reader to avoid blocking, but the door stays open.

What it costs is that the partitions have to actually be there, hence a year of
runway and headroom as the alert.

## `fpindex_meta`: what retention threw away

The changelog cannot express its own gaps. A consumer tailing
`WHERE id > cursor` that has fallen behind the retention window gets back an
empty result — which is exactly what it gets when it is up to date. Nothing in
the log distinguishes "no changes since your cursor" from "the changes since
your cursor were dropped a fortnight ago", and the second one silently produces
an index that is missing fingerprints forever.

So retention records the highest row it removed, in a one-row table:

```sql
SELECT last_deleted_id FROM fpindex_meta;
```

A consumer at `cursor` is resumable from the log alone iff
`cursor >= last_deleted_id`. Below that, the ids in `(cursor, last_deleted_id]`
are gone and it has to bootstrap from a peer snapshot. No row at all means
nothing has ever been deleted, which is the truth on a fresh install and saves
seeding the same row from both the migration and `create_all`.

`last_deleted_created` and `last_deleted_xid` ride along for the same reason the
changelog carries them: diagnostics, and they keep a snapshot-horizon read
strategy possible without another migration.

One row, enforced by the schema rather than by the job
(`singleton boolean PRIMARY KEY CHECK (singleton)`). That mirrors the
changelog's own decision not to carry a lineage dimension — one stream, one
watermark — and if a per-index dimension ever arrives, both tables gain it
together.

Two ordering decisions carry the safety argument:

- The watermark is written **before** the drop and commits separately from it.
  If the drop then fails, the watermark is merely conservative: it claims rows
  are gone while they are still there, so a consumer sitting right on the
  boundary bootstraps once for nothing and the next run drops the partition
  anyway. The other order has no such margin — the rows vanish, nothing records
  that they did, and the consumer concludes it is up to date.
- If the watermark write itself fails, the partition is **not** dropped.

It is a single `INSERT ... SELECT ... ON CONFLICT DO UPDATE`, so the row read
and the row written cannot disagree, an empty partition naturally records
nothing, and no `xid8` value round-trips through Python. The `DO UPDATE` is
guarded on the id increasing: drops go oldest first so it should never bind, but
a watermark that went backwards would re-authorise a cursor that is no longer
resumable.

## Measured, not assumed (PG 17.4)

- `DROP TABLE <partition>` and `DETACH PARTITION` take identical locks: ACCESS
  EXCLUSIVE on both parent and partition. Creating a partition that does not
  exist yet takes ACCESS EXCLUSIVE on the parent too.
- **Partition pruning does not avoid the lock.** All partitions are locked at
  plan time, before pruning runs. A reader with an explicit `created >=`
  predicate that prunes the old partition away still blocks the drop.
- An idle-in-transaction session that never touched the table does *not* block
  it.
- A **no-op** `CREATE TABLE IF NOT EXISTS` does not take the parent lock at all
  — the relation is checked before the lock is acquired. So all but one of the
  thirteen calls a month is free, and the steady-state cost of the job is nil.
- While a real `CREATE TABLE ... PARTITION OF` is queued waiting for the parent,
  new INSERTs queue behind it — and those INSERTs are the trigger. `lock_timeout`
  therefore covers creates, not just drops; without it the wait is unbounded,
  since the maintenance connection sets no `statement_timeout`.
- Consequence, and it's a constraint on whatever reads this feed rather than on
  the retention job: **a consumer must not hold a transaction open across a
  long-poll wait.** Query, end the transaction, wait outside it, query again.

## Tests

Full suite: **185 passed, 1 skipped**. Without the new file it's 168, so exactly
+17 and nothing existing disturbed — worth stating, because the trigger fires on
every fingerprint insert in the whole suite, and with no default partition every
one of those inserts now depends on the `create_all` hook having built the
current month.

`isort`, `black`, `flake8`, `mypy` clean on the scope `check.sh` uses.

Two tests were checked against their own absence rather than just asserted:

- with `pg_advisory_xact_lock` commented out of the trigger,
  `test_second_writer_blocks_until_the_first_commits` fails with `DID NOT RAISE`
- with `now()` substituted for `clock_timestamp()`,
  `test_created_follows_the_lock_not_the_transaction_start` fails. The older
  sequential timestamp test passes either way, which is why the second one
  exists — it stages a writer whose transaction starts earlier but takes the
  changelog id later.

**CI now runs the migrations.** The suite builds its database with `create_all`,
so nothing here ever ran a migration — the chain was only as good as whoever
last ran it by hand. A new step runs `alembic upgrade head` against the
`acoustid_app` / `acoustid_fingerprint` / `acoustid_ingest` databases that
`create_db.sql` already creates and the tests never touch.

Switching the tests themselves to migrations is a much bigger job and is not
this. `alembic/env.py` configures each database without a `version_table`, so
all three share the default `alembic_version`; against the single
`acoustid_test` database the tests use, `app` runs the whole chain, stamps the
table, and `fingerprint` and `ingest` then read that same row, conclude they are
at head, and create nothing — verified, you end up with `account` and no
`fingerprint`, `fpindex_changelog` or `submission`. Migrations also skip the
`musicbrainz` schema, which several tests need. Three separate databases is what
the multi-database setup expects, which is exactly what the new step gives it.

Also exercised by hand against PG 17.4, beyond what CI asserts: the deploy
scenario itself — the first fingerprint insert after the migration lands in the
current month's partition, with thirteen partitions and no default. Downgrade
leaves no `fpindex_%` relations and no trigger, and re-upgrade works.
`\d fpindex_meta` is byte-identical between the `create_all` and migration
paths. The real `run_manage_fpindex_changelog` drops a staged 2020-03 partition
— logging *"the log now resumes after id 3"*, with the watermark carrying the
right id, timestamp and xid — reports 13 months of headroom, and is a clean
no-op on a second pass.

## Not covered

- **Nothing reads the changelog.** No feed endpoint, no consumer — so nothing
  yet performs the `cursor >= last_deleted_id` check that `fpindex_meta` exists
  to make possible.
- `RETENTION_MONTHS = 2` and `CREATE_AHEAD_MONTHS = 12` are module constants, not
  config. Fine for an experiment, not for production.
- No backfill: the log starts empty and only records inserts from the migration
  onwards. A consumer bootstrapping from an empty index would need a separate
  path.
- Headroom is logged but has no alert wired to it. That's the condition worth
  alerting on — not the job succeeding, since a job that silently stops running
  is exactly what headroom defends against.
- The lock key is duplicated between `tables.py` and the migration and guarded
  by a test, because divergence there would silently stop serialising writers.
  The partition naming convention is duplicated the same way but only guarded
  indirectly: a partition the task cannot recognise is one it will neither count
  nor drop, so the symptom would be headroom reading zero.


