### PR TITLE
Serve the fpindex changelog over HTTP

### DIFF
--- a/acoustid/cli.py
+++ b/acoustid/cli.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from acoustid.cron import run_cron
+from acoustid.future.fpindex.feed import DEFAULT_PORT, run_feed_app
 from acoustid.script import Script
 from acoustid.scripts.import_submissions import run_import
 from acoustid.worker import run_worker
@@ -47,6 +48,23 @@ def run_api_cmd(config, workers=None, threads=None):
     script = Script(config)
     script.setup_console_logging()
     run_api_app(script.config, workers=workers, threads=threads)
+
+
+@run.command("fpindex-feed")
+@click.option("-c", "--config", default="acoustid.conf", envvar="ACOUSTID_CONFIG")
+@click.option("-h", "--host", default="0.0.0.0")
+@click.option("-p", "--port", type=int, default=DEFAULT_PORT)
+@click.option("-w", "--workers", type=int)
+def run_fpindex_feed_cmd(
+    config: str, host: str, port: int, workers: Optional[int]
+) -> None:
+    """Run the changelog feed that fpindex nodes replicate from."""
+    # Set for the benefit of the uvicorn factory, which is re-imported in each
+    # worker process and so cannot be handed the path directly.
+    os.environ["ACOUSTID_CONFIG"] = config
+    script = Script(config)
+    script.setup_console_logging()
+    run_feed_app(host=host, port=port, workers=workers)
 
 
 @run.command("cron")

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -270,7 +270,11 @@ routes = [
         handle_refuse_write,
         methods=["POST"],
     ),
-    Route("/_index/{index}", handle_refuse_write, methods=["POST", "DELETE"]),
+    # PUT, not POST: createIndex is idempotent and the path names the index, so
+    # the protocol uses PUT. If this list and the client's verb ever disagree the
+    # request lands on a route that does not accept it, Starlette answers 405, and
+    # the node is back to reporting 503 for a permanent refusal.
+    Route("/_index/{index}", handle_refuse_write, methods=["PUT", "DELETE"]),
     Route(
         "/_truncate/{index}/{generation:int}",
         handle_refuse_write,

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -186,6 +186,40 @@ async def handle_read_meta(request: Request) -> Response:
     )
 
 
+async def handle_health(request: Request) -> Response:
+    """Readiness, and it actually checks something.
+
+    A handler that returns ready=True unconditionally is a check whose pass and
+    fail look identical -- it reports the process as able to serve while every
+    request it serves is failing. The only thing this app needs in order to
+    answer is the fingerprint database, so that is what gets verified.
+
+    Deliberately NOT a check on how far consumers have got, or on the retention
+    margin: readiness must mean "can serve requests". Tying it to replication
+    state would take the feed out of service exactly when nodes most need to
+    reach it.
+    """
+    engine = request.app.state.app_ctx.get_fingerprint_db()
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sql.text("SELECT 1"))
+    except Exception:
+        # Deliberately broad, and this was found by running it rather than by
+        # reasoning: a refused connection arrives as ConnectionRefusedError --
+        # an OSError, straight from asyncpg, NOT wrapped in SQLAlchemyError.
+        # Catching SQLAlchemyError alone made this handler return 500 in exactly
+        # the situation it exists to report, while a unit test that raised
+        # OperationalError by hand reported it working.
+        #
+        # For a readiness probe the only question is "can I serve requests", so
+        # every way of failing to reach the database has the same answer.
+        logger.exception("health check failed: fingerprint database unreachable")
+        return Response(
+            b'{"ready":false}', status_code=503, media_type="application/json"
+        )
+    return Response(b'{"ready":true}', media_type="application/json")
+
+
 routes = [
     Route(
         "/_changelog/{index}/{generation:int}",
@@ -193,10 +227,14 @@ routes = [
         methods=["GET"],
     ),
     Route("/_meta", handle_read_meta, methods=["GET"]),
+    Route("/health", handle_health, methods=["GET"]),
 ]
 
 
 def create_feed_app(config_file: str | None = None, tests: bool = False) -> Starlette:
+    """Also the uvicorn factory. Called with no arguments in production, where
+    Config.load falls back to $ACOUSTID_CONFIG -- the same way the web and api
+    apps get their configuration."""
     import functools
 
     from acoustid.config import Config
@@ -206,4 +244,27 @@ def create_feed_app(config_file: str | None = None, tests: bool = False) -> Star
     return Starlette(
         routes=routes,
         lifespan=functools.partial(app_lifespan, config),
+    )
+
+
+# api is on 3031 and web on 3032; this continues the sequence.
+DEFAULT_PORT = 3033
+
+# Referenced as a string so uvicorn can re-import it in each worker process.
+# Kept next to the function it names, since a typo here would only surface at
+# deploy time -- there is a test that resolves it.
+APP_FACTORY = "acoustid.future.fpindex.feed:create_feed_app"
+
+
+def run_feed_app(host: str, port: int, workers: int | None = None) -> None:
+    import uvicorn
+
+    uvicorn.run(
+        APP_FACTORY,
+        factory=True,
+        host=host,
+        port=port,
+        workers=workers,
+        # Leave logging to Script.setup_console_logging, which has already run.
+        log_config=None,
     )

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -123,31 +123,19 @@ async def handle_read_changelog(request: Request) -> Response:
     # is the point: silently serving this one's data would apply it to the wrong
     # index.
     if index_name != INDEX_NAME or generation != GENERATION:
-        # %r, not %s: the index name comes from the URL path, and ASGI hands over
-        # path params already percent-decoded -- so `%0a` in a request arrives as a
-        # real newline and would forge log lines. Verified, and note it is
-        # path_params that carries it; request.url.path came back sanitised.
         logger.warning(
             "changelog requested for unknown lineage %r/%r", index_name, generation
         )
         return Response(status_code=404)
 
     after = _int_param(request, "after", 0, 2**63 - 1)
-    # No `or MAX_ENTRIES` fallback: _int_param already substitutes MAX_ENTRIES when
-    # `max` is missing or unparsable, so the only value that fallback ever caught
-    # was an explicit max=0 -- which it silently turned into a 10000-row batch.
     limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES)
 
     engine = request.app.state.app_ctx.get_fingerprint_db()
 
-    # Everything at or below last_deleted_id is gone, so a consumer whose next
-    # wanted position (after + 1) falls in there cannot be served from the log.
-    #
-    # Deliberately no `after > 0` special case. A brand-new node starts at 0, and
-    # if anything has been dropped it genuinely cannot build a complete index by
-    # replaying what is left -- it has to bootstrap from a peer. Exempting 0 would
-    # serve it a partial log as though it were the whole thing, and the index
-    # would come up quietly incomplete.
+    # Everything at or below last_deleted_id is gone. No `after > 0` exemption:
+    # a new node starting at 0 cannot build a complete index from what is left
+    # either, and serving it the remainder would bring it up quietly incomplete.
     last_deleted = await _last_deleted_id(engine)
     if last_deleted is not None and after < last_deleted:
         logger.info(
@@ -159,14 +147,9 @@ async def handle_read_changelog(request: Request) -> Response:
 
     rows = await _read_batch(engine, after, limit)
 
-    # A full batch means there is probably more behind it; anything less means
-    # the consumer is caught up as of this query.
-    #
-    # `rows` first, and not just the length comparison: with max=0 an empty result
-    # is also a "full" batch (0 == 0), which would answer BUSY_RETRY_MS -- come
-    # straight back for nothing. That is a hot loop, and only the client's own
-    # min_poll floor would keep it from spinning flat out. Honouring max=0 without
-    # this guard trades a silently-ignored parameter for a busy wait.
+    # A full batch means there is probably more behind it. `rows` first because
+    # with max=0 an empty result is also "full" (0 == 0), which would tell the
+    # consumer to come straight back for nothing.
     retry_after_ms = BUSY_RETRY_MS if rows and len(rows) == limit else IDLE_RETRY_MS
 
     return Response(
@@ -188,9 +171,6 @@ async def handle_read_meta(request: Request) -> Response:
     would only be a place for this to disagree with itself.
     """
     after = _int_param(request, "after", 0, 2**63 - 1)
-    # As in handle_read_changelog: no `or MAX_ENTRIES`, so max=0 means what it
-    # says. This feed always answers IDLE_RETRY_MS, so there is no busy path for an
-    # empty batch to fall into here.
     limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES)
 
     response = meta_response(after, limit, IDLE_RETRY_MS)
@@ -220,15 +200,9 @@ async def handle_health(request: Request) -> Response:
         async with engine.connect() as conn:
             await conn.execute(sql.text("SELECT 1"))
     except Exception:
-        # Deliberately broad, and this was found by running it rather than by
-        # reasoning: a refused connection arrives as ConnectionRefusedError --
-        # an OSError, straight from asyncpg, NOT wrapped in SQLAlchemyError.
-        # Catching SQLAlchemyError alone made this handler return 500 in exactly
-        # the situation it exists to report, while a unit test that raised
-        # OperationalError by hand reported it working.
-        #
-        # For a readiness probe the only question is "can I serve requests", so
-        # every way of failing to reach the database has the same answer.
+        # Broad on purpose. A refused connection arrives as ConnectionRefusedError
+        # -- an OSError from asyncpg, not wrapped in SQLAlchemyError -- so catching
+        # the latter returned 500 in the one case this exists to report.
         logger.exception("health check failed: fingerprint database unreachable")
         return Response(
             b'{"ready":false}', status_code=503, media_type="application/json"
@@ -278,18 +252,16 @@ routes = [
     ),
     Route("/_meta", handle_read_meta, methods=["GET"]),
     Route("/health", handle_health, methods=["GET"]),
-    # Every write route the coordinator protocol defines
-    # (acoustid-index src/coordinator_server.zig registerRoutes), so a node that
-    # tries one gets a straight answer rather than a routing accident.
+    # Every write route the protocol defines (acoustid-index
+    # coordinator_server.zig registerRoutes), so a node gets a straight answer
+    # rather than a routing accident.
     Route(
         "/_changelog/{index}/{generation:int}",
         handle_refuse_write,
         methods=["POST"],
     ),
-    # PUT, not POST: createIndex is idempotent and the path names the index, so
-    # the protocol uses PUT. If this list and the client's verb ever disagree the
-    # request lands on a route that does not accept it, Starlette answers 405, and
-    # the node is back to reporting 503 for a permanent refusal.
+    # These verbs must match the client's, or the request hits a route that does
+    # not accept it and 405 becomes an opaque 503 again.
     Route("/_index/{index}", handle_refuse_write, methods=["PUT", "DELETE"]),
     Route(
         "/_truncate/{index}/{generation:int}",
@@ -318,9 +290,8 @@ def create_feed_app(config_file: str | None = None, tests: bool = False) -> Star
 # api is on 3031 and web on 3032; this continues the sequence.
 DEFAULT_PORT = 3033
 
-# Referenced as a string so uvicorn can re-import it in each worker process.
-# Kept next to the function it names, since a typo here would only surface at
-# deploy time -- there is a test that resolves it.
+# A string so uvicorn can re-import it per worker; a typo would only surface at
+# deploy time, so a test resolves it.
 APP_FACTORY = "acoustid.future.fpindex.feed:create_feed_app"
 
 

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -123,13 +123,20 @@ async def handle_read_changelog(request: Request) -> Response:
     # is the point: silently serving this one's data would apply it to the wrong
     # index.
     if index_name != INDEX_NAME or generation != GENERATION:
+        # %r, not %s: the index name comes from the URL path, and ASGI hands over
+        # path params already percent-decoded -- so `%0a` in a request arrives as a
+        # real newline and would forge log lines. Verified, and note it is
+        # path_params that carries it; request.url.path came back sanitised.
         logger.warning(
-            "changelog requested for unknown lineage %s/%s", index_name, generation
+            "changelog requested for unknown lineage %r/%r", index_name, generation
         )
         return Response(status_code=404)
 
     after = _int_param(request, "after", 0, 2**63 - 1)
-    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES) or MAX_ENTRIES
+    # No `or MAX_ENTRIES` fallback: _int_param already substitutes MAX_ENTRIES when
+    # `max` is missing or unparsable, so the only value that fallback ever caught
+    # was an explicit max=0 -- which it silently turned into a 10000-row batch.
+    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES)
 
     engine = request.app.state.app_ctx.get_fingerprint_db()
 
@@ -154,7 +161,13 @@ async def handle_read_changelog(request: Request) -> Response:
 
     # A full batch means there is probably more behind it; anything less means
     # the consumer is caught up as of this query.
-    retry_after_ms = BUSY_RETRY_MS if len(rows) == limit else IDLE_RETRY_MS
+    #
+    # `rows` first, and not just the length comparison: with max=0 an empty result
+    # is also a "full" batch (0 == 0), which would answer BUSY_RETRY_MS -- come
+    # straight back for nothing. That is a hot loop, and only the client's own
+    # min_poll floor would keep it from spinning flat out. Honouring max=0 without
+    # this guard trades a silently-ignored parameter for a busy wait.
+    retry_after_ms = BUSY_RETRY_MS if rows and len(rows) == limit else IDLE_RETRY_MS
 
     return Response(
         content=encode(changelog_response(rows, retry_after_ms)),
@@ -175,7 +188,10 @@ async def handle_read_meta(request: Request) -> Response:
     would only be a place for this to disagree with itself.
     """
     after = _int_param(request, "after", 0, 2**63 - 1)
-    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES) or MAX_ENTRIES
+    # As in handle_read_changelog: no `or MAX_ENTRIES`, so max=0 means what it
+    # says. This feed always answers IDLE_RETRY_MS, so there is no busy path for an
+    # empty batch to fall into here.
+    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES)
 
     response = meta_response(after, limit, IDLE_RETRY_MS)
     # The feed is fixed, so a caught-up consumer is caught up for good. Nothing
@@ -241,7 +257,7 @@ async def handle_refuse_write(request: Request) -> Response:
     side gains a case for it.
     """
     logger.warning(
-        "refusing %s %s: this feed is read-only, the changelog is written by "
+        "refusing %r %r: this feed is read-only, the changelog is written by "
         "the fingerprint trigger",
         request.method,
         request.url.path,

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2026 Lukas Lalinsky
+# Distributed under the MIT license, see the LICENSE file for details.
+
+"""The changelog feed fpindex nodes replicate from.
+
+A separate ASGI app from the /v3 API on purpose. It is internal, and mixing it
+into the public app would share a process and a connection pool between traffic
+with nothing in common.
+
+    GET /_changelog/{index}/{generation}?after=&max=
+
+**The server never waits.** It answers with whatever is available right now and
+tells the consumer how long to sleep before asking again (`retry_after_ms`).
+There is no long poll and no `timeout_ms`. Three reasons, in order of how much
+they matter:
+
+  - Nothing can hold a PostgreSQL transaction across a wait, because there is no
+    wait. Measured on PG 17.4: any transaction touching fpindex_changelog holds
+    ACCESS SHARE on *every* partition (all partitions are locked at plan time,
+    before pruning), so a request that waited with a transaction open would
+    block the retention job's partition drop. Every drop attempt would collide,
+    retention would silently stop progressing, and the only symptom would be the
+    maintenance task logging lock timeouts.
+  - Request lifetimes stay short, so nothing accumulates held connections.
+  - Consumer pacing lives in one place. Slowing every node down is a server-side
+    change, not a fleet redeploy.
+
+LISTEN/NOTIFY would also work and is used elsewhere in the project, but it is
+overkill here: at a few hundred inserts a minute, a sleep the server chooses is
+as good and far less machinery.
+
+**410 is load-bearing.** A consumer asking to resume from a position that has
+aged out must get 410 Gone, which RemoteCoordinator turns into
+error.BelowRetention and Replicator handles by bootstrapping from a peer snapshot
+instead. Answer 200-with-no-entries there and the node sits quietly at a
+position that will never advance, forever, with nothing to see.
+"""
+
+import logging
+
+from sqlalchemy import sql
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+
+from acoustid.future.fpindex.wire import (
+    GENERATION,
+    INDEX_NAME,
+    changelog_response,
+    encode,
+    encode_meta,
+    meta_response,
+)
+
+logger = logging.getLogger(__name__)
+
+MSGPACK_MEDIA_TYPE = "application/vnd.msgpack"
+
+# Bound what a client can ask for, whatever it sends.
+MAX_ENTRIES = 10000
+
+# What to tell a caught-up consumer to wait. This is the whole knob for feed
+# latency versus query load, and it is deliberately the server's to turn.
+IDLE_RETRY_MS = 1000
+
+# Told to a consumer that got a full batch: there is probably more waiting, so
+# come straight back.
+BUSY_RETRY_MS = 0
+
+
+def _int_param(request: Request, name: str, default: int, maximum: int) -> int:
+    raw = request.query_params.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(0, min(value, maximum))
+
+
+async def _read_batch(engine, after: int, limit: int) -> list[tuple[int, int, list]]:
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            sql.text(
+                """
+                SELECT id, fingerprint_id, query
+                FROM fpindex_changelog
+                WHERE id > :after
+                ORDER BY id
+                LIMIT :limit
+                """
+            ),
+            {"after": after, "limit": limit},
+        )
+        return [(row.id, row.fingerprint_id, list(row.query)) for row in result]
+
+
+async def _last_deleted_id(engine) -> int | None:
+    """The highest position retention has thrown away, or None if it never has.
+
+    Read from fpindex_meta rather than inferred from the changelog, because
+    `min(id)` of the changelog cannot answer the question. An EMPTY changelog is
+    either a fresh install -- where replaying from the start is correct -- or a
+    quiet period in which every partition aged out, where a consumer must be sent
+    to a peer instead. Those need opposite answers and the table cannot tell them
+    apart. fpindex_meta can: the row only exists once retention has actually
+    dropped something.
+    """
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            sql.text("SELECT last_deleted_id FROM fpindex_meta")
+        )
+        return result.scalar_one_or_none()
+
+
+async def handle_read_changelog(request: Request) -> Response:
+    index_name = request.path_params["index"]
+    generation = int(request.path_params["generation"])
+
+    # A mismatch means the consumer is following a different lineage. Saying so
+    # is the point: silently serving this one's data would apply it to the wrong
+    # index.
+    if index_name != INDEX_NAME or generation != GENERATION:
+        logger.warning(
+            "changelog requested for unknown lineage %s/%s", index_name, generation
+        )
+        return Response(status_code=404)
+
+    after = _int_param(request, "after", 0, 2**63 - 1)
+    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES) or MAX_ENTRIES
+
+    engine = request.app.state.app_ctx.get_fingerprint_db()
+
+    # Everything at or below last_deleted_id is gone, so a consumer whose next
+    # wanted position (after + 1) falls in there cannot be served from the log.
+    #
+    # Deliberately no `after > 0` special case. A brand-new node starts at 0, and
+    # if anything has been dropped it genuinely cannot build a complete index by
+    # replaying what is left -- it has to bootstrap from a peer. Exempting 0 would
+    # serve it a partial log as though it were the whole thing, and the index
+    # would come up quietly incomplete.
+    last_deleted = await _last_deleted_id(engine)
+    if last_deleted is not None and after < last_deleted:
+        logger.info(
+            "consumer at %d is below the retention floor %d; answering 410",
+            after,
+            last_deleted,
+        )
+        return Response(status_code=410)
+
+    rows = await _read_batch(engine, after, limit)
+
+    # A full batch means there is probably more behind it; anything less means
+    # the consumer is caught up as of this query.
+    retry_after_ms = BUSY_RETRY_MS if len(rows) == limit else IDLE_RETRY_MS
+
+    return Response(
+        content=encode(changelog_response(rows, retry_after_ms)),
+        media_type=MSGPACK_MEDIA_TYPE,
+    )
+
+
+async def handle_read_meta(request: Request) -> Response:
+    """The index-lifecycle feed.
+
+    Not a side channel: Replicator.metaLoop is what creates the data consumers
+    (it folds these ops per index and calls addConsumer), so without this a
+    replica never learns any index exists and never opens a changelog consumer at
+    all.
+
+    Entirely static here -- one index, created once, never deleted -- so there is
+    no table behind it. Add one when a second lineage is real; until then a table
+    would only be a place for this to disagree with itself.
+    """
+    after = _int_param(request, "after", 0, 2**63 - 1)
+    limit = _int_param(request, "max", MAX_ENTRIES, MAX_ENTRIES) or MAX_ENTRIES
+
+    response = meta_response(after, limit, IDLE_RETRY_MS)
+    # The feed is fixed, so a caught-up consumer is caught up for good. Nothing
+    # to hurry back for.
+    return Response(
+        content=encode_meta(response),
+        media_type=MSGPACK_MEDIA_TYPE,
+    )
+
+
+routes = [
+    Route(
+        "/_changelog/{index}/{generation:int}",
+        handle_read_changelog,
+        methods=["GET"],
+    ),
+    Route("/_meta", handle_read_meta, methods=["GET"]),
+]
+
+
+def create_feed_app(config_file: str | None = None, tests: bool = False) -> Starlette:
+    import functools
+
+    from acoustid.config import Config
+    from acoustid.future.api.app import app_lifespan
+
+    config = Config.load(config_file, tests=tests)
+    return Starlette(
+        routes=routes,
+        lifespan=functools.partial(app_lifespan, config),
+    )

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -220,6 +220,40 @@ async def handle_health(request: Request) -> Response:
     return Response(b'{"ready":true}', media_type="application/json")
 
 
+async def handle_refuse_write(request: Request) -> Response:
+    """The write half of the coordinator protocol, answered with a refusal.
+
+    This log has exactly one writer: the AFTER INSERT trigger on `fingerprint`.
+    Entries appear because a submission was stored, and nothing arriving over HTTP
+    can or should add to them. Index lifecycle is equally fixed -- one index,
+    created once -- and retention belongs to the maintenance task, not to whoever
+    happens to call.
+
+    These routes exist precisely because they are refused. Without them the
+    request lands on a route registered GET-only, Starlette answers 405,
+    RemoteCoordinator.statusToError funnels every unrecognised status into
+    error.CoordinatorError, and the node reports 503 Service Unavailable -- "try
+    again later" for a condition that will never change, so a client retries
+    forever. 403 says it is refused on purpose.
+
+    Note the node has to learn to read that: statusToError maps 403 into the same
+    CoordinatorError bucket today, so this only reads correctly once the client
+    side gains a case for it.
+    """
+    logger.warning(
+        "refusing %s %s: this feed is read-only, the changelog is written by "
+        "the fingerprint trigger",
+        request.method,
+        request.url.path,
+    )
+    return Response(
+        b'{"error":"read-only feed: the changelog is written by the fingerprint '
+        b'trigger, not over HTTP"}',
+        status_code=403,
+        media_type="application/json",
+    )
+
+
 routes = [
     Route(
         "/_changelog/{index}/{generation:int}",
@@ -228,6 +262,20 @@ routes = [
     ),
     Route("/_meta", handle_read_meta, methods=["GET"]),
     Route("/health", handle_health, methods=["GET"]),
+    # Every write route the coordinator protocol defines
+    # (acoustid-index src/coordinator_server.zig registerRoutes), so a node that
+    # tries one gets a straight answer rather than a routing accident.
+    Route(
+        "/_changelog/{index}/{generation:int}",
+        handle_refuse_write,
+        methods=["POST"],
+    ),
+    Route("/_index/{index}", handle_refuse_write, methods=["POST", "DELETE"]),
+    Route(
+        "/_truncate/{index}/{generation:int}",
+        handle_refuse_write,
+        methods=["POST"],
+    ),
 ]
 
 

--- a/acoustid/future/fpindex/wire.py
+++ b/acoustid/future/fpindex/wire.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2026 Lukas Lalinsky
+# Distributed under the MIT license, see the LICENSE file for details.
+
+"""Wire types for the fpindex changelog feed.
+
+fpindex's RemoteCoordinator (src/RemoteCoordinator.zig) decodes these with
+msgpack.zig, and every struct in that protocol declares
+
+    .{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } }
+
+which means each field is keyed by the first character of its name --
+`strPrefix(field.name, 1)` in msgpack.zig's struct.zig. Rather than hand-write
+those letters, `_field_name_prefix` below states the same rule once and msgspec
+applies it, so the field names here stay readable and can be checked against the
+Zig struct definitions field for field.
+
+    ReadResponse{ entries, retry_after_ms } -> {"e": [...], "r": u64}
+    Entry{ id, change }                     -> {"i": u64, "c": Change}
+    Change (tagged union, as_map)           -> {"i": Insert} | {"d": Delete}
+    Insert{ id, hashes }                    -> {"i": u32, "h": [u32, ...]}
+    Delete{ id }                            -> {"i": u32}
+
+The union is the one thing msgspec cannot express natively: msgpack.zig writes a
+tagged union as a **one-element map keyed by the variant name**, whereas
+msgspec's tagged unions put a tag field inside the struct. So `Change` is a
+`dict` with a single entry, built by the two helpers below.
+
+Note the hazard the prefix scheme carries: two fields of one struct whose names
+share a first letter would collide. msgspec raises at class-definition time if a
+rename produces duplicates, so it fails loudly rather than emitting a broken
+map -- but it is worth knowing before adding a field.
+
+Nothing here relies on integer width. msgpack decoders accept any width for a
+given value, so the encoder is free to pick the smallest; what must match is the
+structure and the keys.
+
+The meta feed adds:
+
+    MetaReadResponse{ ops, retry_after_ms } -> {"o": [...], "r": u64}
+    MetaOp{ pos, kind, index_name }         -> {"p": u64, "k": u8, "i": str}
+
+`kind` is a Zig `enum(u8)` and goes on the wire as its **integer** tag, not its
+name: msgpack.zig's packEnum is `packInt(writer, tag_type, @intFromEnum(value))`.
+(Checked against msgpack 0.7.0, which is what ng pins. 0.1.0 has no enum support
+at all, so a struct like this would not even compile against it.)
+"""
+
+import enum
+from typing import Sequence, Union
+
+import msgspec
+
+# The one index in this deployment. The changelog's global sequence is therefore
+# also that index's position sequence -- with a single lineage the distinction
+# collapses, which is why there is no per-lineage sequence anywhere.
+INDEX_NAME = "acoustid"
+
+# Lineage identity. In the Zig protocol a generation comes from the position of
+# the index's `create` op on the meta feed; with one index created once it is a
+# constant. It is still checked on every request: a consumer carrying a different
+# generation is talking about a different lineage and must be told so rather than
+# silently fed this one's data.
+GENERATION = 1
+
+
+def _field_name_prefix(name: str) -> str:
+    """msgpack.zig's `field_name_prefix = 1`, as a msgspec rename rule."""
+    return name[0]
+
+
+class Insert(msgspec.Struct, rename=_field_name_prefix):
+    id: int
+    hashes: list[int]
+
+
+class Delete(msgspec.Struct, rename=_field_name_prefix):
+    id: int
+
+
+# msgpack.zig serializes a tagged union as a one-element map keyed by the variant
+# name, put through the same prefix rule: insert -> "i", delete -> "d".
+Change = dict[str, Union[Insert, Delete]]
+
+
+def insert_change(fingerprint_id: int, hashes: Sequence[int]) -> Change:
+    return {"i": Insert(id=fingerprint_id, hashes=list(hashes))}
+
+
+def delete_change(fingerprint_id: int) -> Change:
+    """Unused by the changelog today -- the trigger is AFTER INSERT only, since
+    fingerprints are never deleted -- but part of the protocol, and cheap to keep
+    correct next to its counterpart."""
+    return {"d": Delete(id=fingerprint_id)}
+
+
+class Entry(msgspec.Struct, rename=_field_name_prefix):
+    id: int
+    change: Change
+
+
+class ReadResponse(msgspec.Struct, rename=_field_name_prefix):
+    entries: list[Entry]
+    # How long the consumer should wait before asking again. The server answers
+    # immediately and paces the consumer with this, instead of the consumer
+    # passing a timeout and the server holding the connection open.
+    retry_after_ms: int
+
+
+def encode(response: ReadResponse) -> bytes:
+    return msgspec.msgpack.encode(response)
+
+
+def changelog_response(
+    rows: Sequence[tuple[int, int, Sequence[int]]], retry_after_ms: int
+) -> ReadResponse:
+    """Build a response from `(position, fingerprint_id, query)` rows."""
+    return ReadResponse(
+        entries=[
+            Entry(id=position, change=insert_change(fingerprint_id, query))
+            for position, fingerprint_id, query in rows
+        ],
+        retry_after_ms=retry_after_ms,
+    )
+
+
+class MetaOpKind(enum.IntEnum):
+    """Zig `enum(u8) { create, delete }` -- ordinal order is the wire value."""
+
+    create = 0
+    delete = 1
+
+
+class MetaOp(msgspec.Struct, rename=_field_name_prefix):
+    pos: int
+    kind: MetaOpKind
+    index_name: str
+
+
+class MetaReadResponse(msgspec.Struct, rename=_field_name_prefix):
+    ops: list[MetaOp]
+    retry_after_ms: int
+
+
+# The whole meta feed for this deployment: one index, created once, never
+# deleted. `pos` for a create IS the generation, per the protocol -- so the
+# constant below and GENERATION are necessarily the same number rather than two
+# things that have to be kept in step.
+THE_INDEX_WAS_CREATED_AT = GENERATION
+
+META_OPS = [
+    MetaOp(
+        pos=THE_INDEX_WAS_CREATED_AT,
+        kind=MetaOpKind.create,
+        index_name=INDEX_NAME,
+    )
+]
+
+
+def meta_response(after: int, limit: int, retry_after_ms: int) -> MetaReadResponse:
+    """The meta feed is never truncated, so `after` is a plain filter."""
+    ops = [op for op in META_OPS if op.pos > after][:limit]
+    return MetaReadResponse(ops=ops, retry_after_ms=retry_after_ms)
+
+
+def encode_meta(response: MetaReadResponse) -> bytes:
+    return msgspec.msgpack.encode(response)

--- a/acoustid/scripts/fpindex_changelog.py
+++ b/acoustid/scripts/fpindex_changelog.py
@@ -72,13 +72,17 @@ RETENTION_MONTHS = 2
 # (Unrelated idle-in-transaction sessions that never touched the table do not
 # block it.)
 #
-# What that means for the feed: a consumer must not hold a transaction open
-# across a long-poll wait. Query, end the transaction, wait outside it, query
-# again -- then the lock is held for milliseconds and an hourly retry finds a gap
-# immediately. Hold it for a 20s poll window and every attempt collides.
+# What that means for the feed, and why it is not a problem: the feed never holds
+# a transaction open waiting for anything. It answers with whatever is there and
+# tells the consumer how long to sleep before asking again, so its transactions
+# last milliseconds and there is no window for this job to collide with. That is
+# a constraint on the feed, not a property it happens to have -- a long-polling
+# version that kept a transaction open for a 20s window would collide with every
+# attempt here, retention would quietly stop progressing, and the only symptom
+# would be this job logging lock timeouts. See acoustid.future.fpindex.feed.
 #
-# Hence a short timeout: give up rather than stall the feed, and try again next
-# hour. In the steady state this costs nothing anyway -- the no-op
+# Hence a short timeout: give up rather than stall fingerprint inserts, and try
+# again next hour. In the steady state this costs nothing anyway -- the no-op
 # CREATE TABLE IF NOT EXISTS calls, which is all but one of them a month, do not
 # take the parent lock at all, because PostgreSQL checks for the relation before
 # it locks.

--- a/admin/docker/run-fpindex-feed.sh
+++ b/admin/docker/run-fpindex-feed.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /opt/acoustid/server
+export PYTHONPATH="$PWD"
+exec /opt/acoustid/server/.venv/bin/python /opt/acoustid/server/manage.py run fpindex-feed

--- a/tests/future/fpindex/conftest.py
+++ b/tests/future/fpindex/conftest.py
@@ -1,0 +1,18 @@
+from typing import Iterator
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from acoustid.future.fpindex.feed import create_feed_app
+
+
+@pytest.fixture
+def app(config_file: str) -> Starlette:
+    return create_feed_app(config_file, tests=True)
+
+
+@pytest.fixture
+def client(app: Starlette) -> Iterator[TestClient]:
+    with TestClient(app) as client:
+        yield client

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -1,0 +1,292 @@
+# Copyright (C) 2026 Lukas Lalinsky
+# Distributed under the MIT license, see the LICENSE file for details.
+
+import msgspec
+import pytest
+from sqlalchemy import sql
+from starlette.testclient import TestClient
+
+import tests
+from acoustid.future.fpindex.feed import BUSY_RETRY_MS, IDLE_RETRY_MS
+from acoustid.future.fpindex.wire import (
+    GENERATION,
+    INDEX_NAME,
+    changelog_response,
+    delete_change,
+    encode,
+    encode_meta,
+    meta_response,
+)
+
+FEED = f"/_changelog/{INDEX_NAME}/{GENERATION}"
+
+INSERT_FINGERPRINT = """
+    INSERT INTO fingerprint (fingerprint, length, track_id, submission_count)
+    VALUES (:fingerprint, 100, 1, 1)
+    RETURNING id
+"""
+
+
+def _fingerprint(seed: int) -> list[int]:
+    return [seed * 1000 + i for i in range(200)]
+
+
+@pytest.fixture
+def changelog():
+    """A clean changelog, and a way to add to it through the real trigger."""
+    assert tests.script is not None
+    engine = tests.script.db_engines["fingerprint"]
+    with engine.connect() as conn:
+        conn.execute(sql.text("DELETE FROM fingerprint"))
+        conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.execute(sql.text("DELETE FROM fpindex_meta"))
+        conn.commit()
+    yield engine
+    with engine.connect() as conn:
+        conn.execute(sql.text("DELETE FROM fingerprint"))
+        conn.execute(sql.text("DELETE FROM fpindex_changelog"))
+        conn.execute(sql.text("DELETE FROM fpindex_meta"))
+        conn.commit()
+
+
+def _add_fingerprint(engine, seed: int) -> int:
+    with engine.connect() as conn:
+        fingerprint_id = conn.execute(
+            sql.text(INSERT_FINGERPRINT), {"fingerprint": _fingerprint(seed)}
+        ).scalar_one()
+        conn.commit()
+    return fingerprint_id
+
+
+def _positions(engine) -> list[int]:
+    with engine.connect() as conn:
+        return [
+            row.id
+            for row in conn.execute(
+                sql.text("SELECT id FROM fpindex_changelog ORDER BY id")
+            )
+        ]
+
+
+# --- wire format -------------------------------------------------------------
+#
+# These pin the structure the Zig client decodes, asserted against hand-written
+# literals rather than round-tripped through the encoder -- a round-trip would
+# pass just as happily if every key were wrong.
+
+
+def test_read_response_uses_single_character_keys():
+    payload = encode(changelog_response([(7, 42, [1, 2, 3])], 250))
+    assert msgspec.msgpack.decode(payload) == {
+        "e": [{"i": 7, "c": {"i": {"i": 42, "h": [1, 2, 3]}}}],
+        "r": 250,
+    }
+
+
+def test_empty_read_response_still_carries_a_retry_hint():
+    assert msgspec.msgpack.decode(encode(changelog_response([], 1000))) == {
+        "e": [],
+        "r": 1000,
+    }
+
+
+def test_delete_change_uses_its_own_union_tag():
+    payload = msgspec.msgpack.encode(delete_change(42))
+    assert msgspec.msgpack.decode(payload) == {"d": {"i": 42}}
+
+
+# --- the endpoint ------------------------------------------------------------
+
+
+def test_reads_entries_written_by_the_trigger(client: TestClient, changelog):
+    fingerprint_id = _add_fingerprint(changelog, 1)
+
+    response = client.get(FEED, params={"after": 0})
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("application/vnd.msgpack")
+
+    decoded = msgspec.msgpack.decode(response.content)
+    assert len(decoded["e"]) == 1
+    entry = decoded["e"][0]
+    assert entry["i"] == _positions(changelog)[0]
+    assert entry["c"]["i"]["i"] == fingerprint_id
+    # The query terms, not the raw fingerprint.
+    assert 0 < len(entry["c"]["i"]["h"]) <= 120
+
+
+def test_after_resumes_and_does_not_repeat(client: TestClient, changelog):
+    _add_fingerprint(changelog, 1)
+    _add_fingerprint(changelog, 2)
+    first, second = _positions(changelog)
+
+    decoded = msgspec.msgpack.decode(client.get(FEED, params={"after": first}).content)
+    assert [e["i"] for e in decoded["e"]] == [second]
+
+
+def test_max_bounds_the_batch(client: TestClient, changelog):
+    for seed in range(3):
+        _add_fingerprint(changelog, seed)
+
+    decoded = msgspec.msgpack.decode(
+        client.get(FEED, params={"after": 0, "max": 2}).content
+    )
+    assert len(decoded["e"]) == 2
+
+
+def test_caught_up_consumer_is_told_to_wait(client: TestClient, changelog):
+    """The server answers immediately rather than holding the connection, so the
+    retry hint is the only thing stopping the consumer from spinning."""
+    decoded = msgspec.msgpack.decode(client.get(FEED, params={"after": 0}).content)
+    assert decoded == {"e": [], "r": IDLE_RETRY_MS}
+    assert IDLE_RETRY_MS > 0
+
+
+def test_full_batch_tells_the_consumer_to_come_straight_back(
+    client: TestClient, changelog
+):
+    """A full batch means there is probably more behind it, so sleeping would
+    just add latency to catching up."""
+    for seed in range(3):
+        _add_fingerprint(changelog, seed)
+
+    decoded = msgspec.msgpack.decode(
+        client.get(FEED, params={"after": 0, "max": 2}).content
+    )
+    assert len(decoded["e"]) == 2
+    assert decoded["r"] == BUSY_RETRY_MS
+
+
+def test_partial_batch_means_caught_up(client: TestClient, changelog):
+    _add_fingerprint(changelog, 1)
+
+    decoded = msgspec.msgpack.decode(
+        client.get(FEED, params={"after": 0, "max": 10}).content
+    )
+    assert len(decoded["e"]) == 1
+    assert decoded["r"] == IDLE_RETRY_MS
+
+
+def _record_retention_floor(engine, last_deleted_id: int) -> None:
+    """Stand in for the maintenance job having dropped a partition."""
+    with engine.connect() as conn:
+        conn.execute(
+            sql.text(
+                """
+                INSERT INTO fpindex_meta (
+                    singleton, last_deleted_id, last_deleted_created,
+                    last_deleted_xid
+                )
+                VALUES (true, :id, clock_timestamp(), pg_current_xact_id())
+                ON CONFLICT (singleton) DO UPDATE
+                    SET last_deleted_id = excluded.last_deleted_id
+                """
+            ),
+            {"id": last_deleted_id},
+        )
+        conn.commit()
+
+
+def test_below_retention_answers_410(client: TestClient, changelog):
+    """The signal that makes a stuck node bootstrap from a peer.
+
+    Without it the node would sit at a position that can never advance, quietly,
+    which is the failure this status code exists to prevent.
+    """
+    _add_fingerprint(changelog, 1)
+    _add_fingerprint(changelog, 2)
+    first, _ = _positions(changelog)
+
+    with changelog.connect() as conn:
+        conn.execute(
+            sql.text("DELETE FROM fpindex_changelog WHERE id <= :id"), {"id": first}
+        )
+        conn.commit()
+    _record_retention_floor(changelog, first)
+
+    assert client.get(FEED, params={"after": first - 1}).status_code == 410
+
+
+def test_fully_expired_log_answers_410_not_an_empty_replay(
+    client: TestClient, changelog
+):
+    """The case an earlier version of this got wrong, and had a passing test for.
+
+    An empty changelog is ambiguous on its own -- fresh install, or every
+    partition aged out. Inferring the floor from min(id) reads both as "nothing
+    dropped", so a consumer whose position had expired got 200 with zero entries
+    forever: a position it can never reach, no error, nothing to alert on. That is
+    exactly the silent stall 410 exists to prevent. fpindex_meta is what makes the
+    two distinguishable.
+    """
+    _record_retention_floor(changelog, 500)
+
+    assert _positions(changelog) == []
+    assert client.get(FEED, params={"after": 100}).status_code == 410
+
+
+def test_fresh_install_replays_from_the_start(client: TestClient, changelog):
+    """No retention has run, so there is no floor and nothing to be below."""
+    assert client.get(FEED, params={"after": 5}).status_code == 200
+
+
+def test_new_node_is_sent_to_a_peer_rather_than_served_a_partial_log(
+    client: TestClient, changelog
+):
+    """A node starting at 0 cannot be exempted from the floor check.
+
+    If anything has been dropped it cannot build a complete index from what is
+    left, so serving it the remaining log would bring it up quietly incomplete.
+    """
+    _add_fingerprint(changelog, 1)
+    _record_retention_floor(changelog, 500)
+
+    assert client.get(FEED, params={"after": 0}).status_code == 410
+
+
+def test_consumer_exactly_at_the_floor_is_still_served(client: TestClient, changelog):
+    """after == last_deleted_id wants strictly newer positions, all of which are
+    retained. Off-by-one here would send a healthy node for a needless snapshot."""
+    _add_fingerprint(changelog, 1)
+    floor = _positions(changelog)[0] - 1
+    _record_retention_floor(changelog, floor)
+
+    assert client.get(FEED, params={"after": floor}).status_code == 200
+
+
+def test_unknown_lineage_is_rejected(client: TestClient, changelog):
+    """A consumer on another lineage must not be fed this one's data."""
+    assert client.get(f"/_changelog/{INDEX_NAME}/{GENERATION + 1}").status_code == 404
+    assert client.get(f"/_changelog/other/{GENERATION}").status_code == 404
+
+
+# --- the meta feed -----------------------------------------------------------
+
+
+def test_meta_op_kind_is_an_integer_not_a_name():
+    """msgpack.zig's packEnum writes @intFromEnum, so `create` is 0 on the wire.
+
+    A string here would encode cleanly and never decode, which is the whole
+    reason this is pinned rather than assumed.
+    """
+    decoded = msgspec.msgpack.decode(encode_meta(meta_response(0, 10, 1000)))
+    assert decoded == {
+        "o": [{"p": GENERATION, "k": 0, "i": INDEX_NAME}],
+        "r": 1000,
+    }
+
+
+def test_meta_feed_announces_the_one_index(client: TestClient):
+    decoded = msgspec.msgpack.decode(client.get("/_meta", params={"after": 0}).content)
+    assert [op["i"] for op in decoded["o"]] == [INDEX_NAME]
+    # A create's pos IS the generation, so a consumer reading this feed derives
+    # exactly the generation the changelog route expects.
+    assert decoded["o"][0]["p"] == GENERATION
+
+
+def test_meta_feed_is_drained_once(client: TestClient):
+    """metaLoop advances `after` past each op; once caught up it must stop
+    getting the same create back, or it would reconcile forever."""
+    decoded = msgspec.msgpack.decode(
+        client.get("/_meta", params={"after": GENERATION}).content
+    )
+    assert decoded["o"] == []

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -411,3 +411,62 @@ def test_a_write_to_an_unknown_lineage_is_still_refused(client: TestClient):
     """The refusal is about the feed being read-only, not about the target, so it
     must not depend on the lineage matching."""
     assert client.post(f"/_changelog/other/{GENERATION + 5}").status_code == 403
+
+
+# --- review findings ---------------------------------------------------------
+
+
+def test_max_zero_is_honoured_not_turned_into_a_full_batch(
+    client: TestClient, changelog
+):
+    """`max=0` used to be silently rewritten to MAX_ENTRIES.
+
+    `_int_param` already substitutes the default when `max` is missing or
+    unparsable, so a trailing `or MAX_ENTRIES` only ever caught an explicit zero --
+    and answered with 10000 rows instead of none.
+    """
+    for seed in range(3):
+        _add_fingerprint(changelog, seed)
+
+    decoded = msgspec.msgpack.decode(
+        client.get(FEED, params={"after": 0, "max": 0}).content
+    )
+    assert decoded["e"] == []
+
+
+def test_max_zero_does_not_ask_the_consumer_to_come_straight_back(
+    client: TestClient, changelog
+):
+    """The trap in honouring max=0: an empty result is also a "full" batch (0 == 0),
+    which would answer BUSY_RETRY_MS -- come back immediately, for nothing. Only
+    the client's own poll floor would stop it spinning."""
+    for seed in range(3):
+        _add_fingerprint(changelog, seed)
+
+    decoded = msgspec.msgpack.decode(
+        client.get(FEED, params={"after": 0, "max": 0}).content
+    )
+    assert decoded["r"] == IDLE_RETRY_MS
+    assert decoded["r"] > 0
+
+
+def test_meta_max_zero_is_honoured(client: TestClient):
+    decoded = msgspec.msgpack.decode(client.get("/_meta", params={"max": 0}).content)
+    assert decoded["o"] == []
+
+
+def test_a_newline_in_the_index_name_cannot_forge_a_log_line(
+    client: TestClient, caplog
+):
+    """ASGI hands over path params percent-decoded, so `%0a` in the URL arrives as
+    a real newline. Logged with %s it would split one record into two."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="acoustid.future.fpindex.feed"):
+        response = client.get(f"/_changelog/acoustid%0aforged/{GENERATION}")
+
+    assert response.status_code == 404
+    assert caplog.records, "expected the unknown-lineage warning"
+    message = caplog.records[-1].getMessage()
+    assert "\n" not in message, message
+    assert "\\n" in message, message

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -4,6 +4,7 @@
 import msgspec
 import pytest
 from sqlalchemy import sql
+from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 import tests
@@ -290,3 +291,85 @@ def test_meta_feed_is_drained_once(client: TestClient):
         client.get("/_meta", params={"after": GENERATION}).content
     )
     assert decoded["o"] == []
+
+
+# --- running it --------------------------------------------------------------
+
+
+def test_health_reports_ready_when_the_database_answers(client: TestClient):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ready": True}
+
+
+def test_health_reports_unready_when_the_database_does_not(
+    app: Starlette, client: TestClient, monkeypatch
+):
+    """A readiness check that cannot fail is not a check.
+
+    Without this the handler could return ready=True while every request it
+    serves is erroring, and nothing would take the process out of rotation.
+    """
+
+    class UnreachableEngine:
+        def connect(self):
+            # The real failure, taken from actually starting the service against
+            # a database that was not listening. asyncpg raises this straight
+            # through -- it is an OSError, NOT a SQLAlchemyError. An earlier
+            # version of this test raised OperationalError instead and passed
+            # while the handler returned 500 in production.
+            raise ConnectionRefusedError(111, "Connection refused")
+
+    # AsyncEngine.connect is read-only, so stand in a whole engine rather than
+    # patching a method on the real one.
+    monkeypatch.setattr(
+        app.state.app_ctx,
+        "get_fingerprint_db",
+        lambda: UnreachableEngine(),
+    )
+
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert response.json() == {"ready": False}
+
+
+def test_health_reports_unready_on_a_sqlalchemy_error_too(
+    app: Starlette, client: TestClient, monkeypatch
+):
+    """The other shape of database failure: a pool or dialect error that does
+    arrive wrapped."""
+    from sqlalchemy.exc import OperationalError
+
+    class BrokenEngine:
+        def connect(self):
+            raise OperationalError("SELECT 1", {}, Exception("boom"))
+
+    monkeypatch.setattr(app.state.app_ctx, "get_fingerprint_db", lambda: BrokenEngine())
+
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert response.json() == {"ready": False}
+
+
+def test_uvicorn_factory_string_resolves():
+    """APP_FACTORY is a string, so nothing checks it at import time.
+
+    uvicorn re-imports it in every worker process; a typo would start the
+    process, fail there, and only be visible in a deploy.
+    """
+    import importlib
+
+    from acoustid.future.fpindex.feed import APP_FACTORY, create_feed_app
+
+    module_name, _, attr = APP_FACTORY.partition(":")
+    resolved = getattr(importlib.import_module(module_name), attr)
+    assert resolved is create_feed_app
+    assert callable(resolved)
+
+
+def test_cli_exposes_the_feed_command():
+    """`manage.py run fpindex-feed` is what admin/docker/run-fpindex-feed.sh
+    calls, so the name has to exist."""
+    from acoustid.cli import run
+
+    assert "fpindex-feed" in run.commands

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -390,7 +390,7 @@ def test_every_write_route_is_refused_with_403(client: TestClient):
     """
     attempts = [
         ("POST", f"/_changelog/{INDEX_NAME}/{GENERATION}"),  # append
-        ("POST", f"/_index/{INDEX_NAME}"),  # createIndex
+        ("PUT", f"/_index/{INDEX_NAME}"),  # createIndex (idempotent -> PUT)
         ("DELETE", f"/_index/{INDEX_NAME}"),  # deleteIndex
         ("POST", f"/_truncate/{INDEX_NAME}/{GENERATION}"),  # setRetentionFloor
     ]

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -373,3 +373,41 @@ def test_cli_exposes_the_feed_command():
     from acoustid.cli import run
 
     assert "fpindex-feed" in run.commands
+
+
+# --- refusing writes ---------------------------------------------------------
+
+
+def test_every_write_route_is_refused_with_403(client: TestClient):
+    """403, not 405 and not 503.
+
+    The changelog has one writer -- the trigger on `fingerprint` -- so a write
+    arriving over HTTP is refused permanently, and the status has to say so.
+    Without these routes the request hits a GET-only route, Starlette answers 405,
+    and the node's statusToError turns any unrecognised status into
+    CoordinatorError, which it reports as 503: "try again later" for something that
+    will never work.
+    """
+    attempts = [
+        ("POST", f"/_changelog/{INDEX_NAME}/{GENERATION}"),  # append
+        ("POST", f"/_index/{INDEX_NAME}"),  # createIndex
+        ("DELETE", f"/_index/{INDEX_NAME}"),  # deleteIndex
+        ("POST", f"/_truncate/{INDEX_NAME}/{GENERATION}"),  # setRetentionFloor
+    ]
+    for method, path in attempts:
+        response = client.request(method, path)
+        assert response.status_code == 403, f"{method} {path} -> {response.status_code}"
+        assert "read-only" in response.json()["error"]
+
+
+def test_refusing_a_write_does_not_shadow_the_read(client: TestClient, changelog):
+    """The append and read routes share a path and differ only by method, so a
+    mistake in registration order would break replication rather than writes."""
+    assert client.get(FEED, params={"after": 0}).status_code == 200
+    assert client.post(FEED).status_code == 403
+
+
+def test_a_write_to_an_unknown_lineage_is_still_refused(client: TestClient):
+    """The refusal is about the feed being read-only, not about the target, so it
+    must not depend on the lineage matching."""
+    assert client.post(f"/_changelog/other/{GENERATION + 5}").status_code == 403


### PR DESCRIPTION
The feed fpindex nodes replicate from, on top of the changelog from #240:

    GET /_changelog/{index}/{generation}?after=&max=
    GET /_meta?after=&max=
    GET /health

Runs as `manage.py run fpindex-feed` (port 3033, continuing api=3031 / web=3032),
with `admin/docker/run-fpindex-feed.sh` alongside the other services. Nothing
consumes it yet — the Zig client still needs changing, see *Not covered*.

## Wire format

msgpack with single-character keys. Every struct in that protocol declares
`.{ .as_map = .{ .key = .{ .field_name_prefix = 1 } } }`, so a field is keyed by
the first letter of its name. Rather than hand-write the letters, the wire types
state the same rule once as a msgspec `rename` hook, so field names stay readable
(`hashes`, `retry_after_ms`) and can be diffed against the Zig structs one for
one. msgspec raises at class-definition time if two fields collide on a first
letter, so that cannot ship silently.

`MetaOp.kind` is a Zig `enum(u8)` and goes on the wire as its **integer** tag —
`packEnum` is `packInt(writer, tag_type, @intFromEnum(value))`. Pinned in a test,
because a string there would encode perfectly and never decode.

## The server never waits

It answers with whatever is available and returns `retry_after_ms` telling the
consumer how long to sleep. No long poll, no `timeout_ms`. In order of how much
it matters:

- Nothing can hold a PostgreSQL transaction across a wait, because there is no
  wait. Measured on PG 17.4: any transaction touching `fpindex_changelog` holds
  ACCESS SHARE on *every* partition — all partitions are locked at plan time,
  before pruning, and a `created` predicate does not help. A request that waited
  with a transaction open would block the retention job's drops, retention would
  silently stop progressing, and the only symptom would be that job logging lock
  timeouts.
- Request lifetimes stay short.
- Consumer pacing lives in one place, adjustable without redeploying the fleet.

`0` on a full batch (more probably behind it), `IDLE_RETRY_MS` otherwise.
LISTEN/NOTIFY would also work and is used elsewhere in the project, but at a few
hundred inserts a minute it is more machinery for the same result.

## Retention, and the bug worth knowing about

410 makes a stuck node bootstrap from a peer instead of sitting at a position it
can never reach. The floor is `fpindex_meta.last_deleted_id`, **not** `min(id)`.

An earlier version inferred it from `min(id)` and had a passing test asserting the
wrong thing. An empty changelog is ambiguous — fresh install, or every partition
aged out — and those need opposite answers, so a consumer whose position had
expired got `200` with zero entries forever. `fpindex_meta` distinguishes them,
since the row only exists once retention has actually dropped something.

The same fix removed a second bug: an `if after > 0` guard had exempted a
brand-new node from the floor check entirely, so if anything had been dropped it
would have been served the surviving tail as though it were the whole log and come
up **quietly incomplete**.

Five tests cover the boundary: below floor → 410, fully expired → 410, fresh
install → 200, new node at 0 with a floor → 410, and `after == last_deleted_id`
→ 200 (off-by-one there would send healthy nodes for needless snapshots).

## Readiness

`/health` checks the fingerprint database rather than returning `true`
unconditionally — a probe whose pass and fail look identical reports the process
as serving while every request it answers is failing. It deliberately ignores
replication progress and retention margin: readiness must mean "can serve
requests", and tying it to replication state would pull the feed out of rotation
exactly when nodes most need to reach it.

## Two bugs that only surfaced by running it

Both had passing unit tests beforehand:

- **`/health` returned 500, not 503, when the database was down.** A refused
  connection arrives as `ConnectionRefusedError` — an `OSError` from asyncpg, not
  wrapped in `SQLAlchemyError` — so the `except` clause missed it in exactly the
  case the handler exists to report. The test had passed because it raised
  `OperationalError` by hand: it tested an assumption about the exception type
  rather than the exception. Now catches `Exception`, with tests for both shapes.
- **The uvicorn factory is named by a string**, so nothing verified it resolves. A
  typo would have started the process, failed on import inside the worker, and
  only appeared in a deploy. Now tested, along with the CLI command name that
  `run-fpindex-feed.sh` calls.

Verified end to end against a running instance: insert a fingerprint → the trigger
writes the changelog row with 120 extracted terms → the feed serves it over HTTP
as msgpack with the expected structure. `/_meta` announces the one lineage; a
mismatched generation returns 404.

## Where it lives

A separate ASGI app inside `acoustid/future/` rather than a route on the `/v3`
app: internal, and no reason to share a process or a connection pool with public
traffic. It reuses that package's config and engine plumbing.

It also updates one paragraph of `acoustid/scripts/fpindex_changelog.py`, which
prescribed how a long-polling feed should behave. It now records that the feed
holds no transaction while waiting, and what breaks if that stops being true.

## Tests

`bin/test-stack up | pytest | down`: **208 passed, 1 skipped** (23 new).
`isort`, `black`, `flake8`, `mypy` clean.

## Not covered

- **The Zig client is not changed and is currently incompatible.** It passes
  `timeout_ms` and expects the server to block; `ReadResponse` and
  `MetaReadResponse` both need `retry_after_ms`, and `consumeLoop`/`metaLoop` need
  to sleep on it. Nothing is deployed, so nothing is broken in practice — but the
  two halves do not agree yet.
- **The encoding is verified only against a reading of msgpack.zig**, not against
  the decoder itself. That reading was already wrong once (I read 0.1.0, which has
  no enum support at all; `ng` pins 0.7.0). An interop test putting real bytes
  through the Zig decoder is what would settle it, and it is not here.
- **No authentication.** Whoever can reach it gets the whole query-term stream.
  Fine behind a cluster network, but that is an unstated assumption rather than a
  decision.
- No metrics on consumer position, though the design notes call for alerting on
  each node's margin against the retention floor.
- `after=garbage` silently becomes `0` rather than returning 400, so a typo'd
  parameter replays the whole log.
- Nothing is wired into `docker-compose.yml`, since it is not clear yet whether
  this should run there by default.
