### PR TITLE
Stream the corpus for a node that has nothing

### DIFF
--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -41,7 +41,7 @@ import logging
 from sqlalchemy import sql
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import Response, StreamingResponse
 from starlette.routing import Route
 
 from acoustid.future.fpindex.wire import (
@@ -49,7 +49,10 @@ from acoustid.future.fpindex.wire import (
     INDEX_NAME,
     changelog_response,
     encode,
+    encode_bootstrap_header,
+    encode_change,
     encode_meta,
+    insert_change,
     meta_response,
 )
 
@@ -67,6 +70,11 @@ IDLE_RETRY_MS = 1000
 # Told to a consumer that got a full batch: there is probably more waiting, so
 # come straight back.
 BUSY_RETRY_MS = 0
+
+# Fingerprints read per transaction while streaming a bootstrap. Each chunk is its
+# own short transaction, so nothing holds a snapshot open across a scan that reads
+# roughly 10 KB per row -- about a terabyte at production scale.
+BOOTSTRAP_CHUNK = 1000
 
 
 def _int_param(request: Request, name: str, default: int, maximum: int) -> int:
@@ -210,6 +218,103 @@ async def handle_health(request: Request) -> Response:
     return Response(b'{"ready":true}', media_type="application/json")
 
 
+async def _current_position(engine) -> int:
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            sql.text("SELECT coalesce(max(id), 0) FROM fpindex_changelog")
+        )
+        return int(result.scalar_one())
+
+
+async def _fingerprints_after(engine, after_id: int, limit: int):
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            sql.text(
+                """
+                SELECT id, acoustid_extract_query(fingerprint) AS query
+                FROM fingerprint
+                WHERE id > :after_id
+                ORDER BY id
+                LIMIT :limit
+                """
+            ),
+            {"after_id": after_id, "limit": limit},
+        )
+        return [(row.id, list(row.query)) for row in result]
+
+
+async def handle_bootstrap(request: Request) -> Response:
+    """Stream the whole current corpus, for a node that has nothing.
+
+    The changelog cannot serve this: it starts at the migration and only records
+    submissions from then on, so replaying it from 0 builds an index missing every
+    fingerprint that already existed.
+
+    Not resumable, and takes no parameters. It runs once per cluster -- one node
+    pays for it and the rest take a peer snapshot of the result -- so an interrupted
+    run just starts over.
+
+    Correct without holding a snapshot open, which is the part worth understanding.
+    `position` is read first, then the table is scanned in chunks, each its own
+    transaction:
+
+      - a fingerprint that existed when `position` was read is still there when its
+        chunk runs, because fingerprints are never deleted or updated, so the chunks
+        cannot miss it,
+      - anything inserted during the scan has a changelog row above `position`,
+        including a straggler that took a low id and committed late into a range
+        already scanned,
+      - replaying from `position` afterwards covers every gap, and the overlap costs
+        nothing because inserts are upserts by document id.
+
+    That matters at 100M rows: a single REPEATABLE READ scan would hold the xmin
+    horizon for the whole run and block vacuum database-wide.
+
+    Streaming also gives backpressure for free. The next chunk is only read once the
+    client has drained the last, so a slow node throttles the scan instead of
+    pulling a terabyte through the primary's buffer cache as fast as it can.
+    """
+    index_name = request.path_params["index"]
+    generation = int(request.path_params["generation"])
+    if index_name != INDEX_NAME or generation != GENERATION:
+        logger.warning(
+            "bootstrap requested for unknown lineage %r/%r", index_name, generation
+        )
+        return Response(status_code=404)
+
+    engine = request.app.state.app_ctx.get_fingerprint_db()
+    position = await _current_position(engine)
+
+    async def stream():
+        last_id = 0
+        streamed = 0
+        while True:
+            rows = await _fingerprints_after(engine, last_id, BOOTSTRAP_CHUNK)
+            if not rows:
+                break
+            for fingerprint_id, query in rows:
+                # An all-silence fingerprint extracts to nothing. Sending it would
+                # add a document with no terms, which can never match.
+                if query:
+                    yield encode_change(insert_change(fingerprint_id, query))
+                last_id = fingerprint_id
+            streamed += len(rows)
+        logger.info(
+            "bootstrap streamed %d fingerprints at position %d", streamed, position
+        )
+
+    return StreamingResponse(
+        _prepend(encode_bootstrap_header(position), stream()),
+        media_type=MSGPACK_MEDIA_TYPE,
+    )
+
+
+async def _prepend(head: bytes, rest):
+    yield head
+    async for chunk in rest:
+        yield chunk
+
+
 async def handle_refuse_write(request: Request) -> Response:
     """The write half of the coordinator protocol, answered with a refusal.
 
@@ -251,6 +356,11 @@ routes = [
         methods=["GET"],
     ),
     Route("/_meta", handle_read_meta, methods=["GET"]),
+    Route(
+        "/_bootstrap/{index}/{generation:int}",
+        handle_bootstrap,
+        methods=["GET"],
+    ),
     Route("/health", handle_health, methods=["GET"]),
     # Every write route the protocol defines (acoustid-index
     # coordinator_server.zig registerRoutes), so a node gets a straight answer

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -49,8 +49,8 @@ from acoustid.future.fpindex.wire import (
     INDEX_NAME,
     changelog_response,
     encode,
+    encode_bootstrap_chunk,
     encode_bootstrap_header,
-    encode_change,
     encode_meta,
     insert_change,
     meta_response,
@@ -253,8 +253,9 @@ async def handle_bootstrap(request: Request) -> Response:
 
     Not resumable. It runs once per cluster -- one node pays for it and the rest
     take a peer snapshot of the result -- so an interrupted run just starts over.
-    The one parameter, `chunk`, only tunes how many rows each transaction reads;
-    it cannot change what the stream contains.
+    The one parameter, `chunk`, tunes how many rows each transaction reads and
+    therefore how the stream is framed into arrays; it cannot change which
+    changes are streamed.
 
     Correct without holding a snapshot open, which is the part worth understanding.
     `position` is read first, then the table is scanned in chunks, each its own
@@ -299,20 +300,19 @@ async def handle_bootstrap(request: Request) -> Response:
             rows = await _fingerprints_after(engine, last_id, chunk)
             if not rows:
                 break
-            # One yield per chunk, not per row: a per-row yield is a hundred
-            # million tiny sends at production scale, each paying its own HTTP
-            # chunk framing. Backpressure is unaffected -- its unit was already
-            # the chunk of database work.
-            parts = []
+            changes = []
             for fingerprint_id, query in rows:
                 # An all-silence fingerprint extracts to nothing. Sending it would
                 # add a document with no terms, which can never match.
                 if query:
-                    parts.append(encode_change(insert_change(fingerprint_id, query)))
+                    changes.append(insert_change(fingerprint_id, query))
                 last_id = fingerprint_id
-            if parts:
-                yield b"".join(parts)
-            streamed += len(parts)
+            # A chunk whose every row extracted to nothing stays off the wire:
+            # an empty array is the terminator, and must mean nothing else.
+            if changes:
+                yield encode_bootstrap_chunk(changes)
+            streamed += len(changes)
+        yield encode_bootstrap_chunk([])
         logger.info(
             "bootstrap streamed %d fingerprints at position %d", streamed, position
         )

--- a/acoustid/future/fpindex/feed.py
+++ b/acoustid/future/fpindex/feed.py
@@ -71,9 +71,10 @@ IDLE_RETRY_MS = 1000
 # come straight back.
 BUSY_RETRY_MS = 0
 
-# Fingerprints read per transaction while streaming a bootstrap. Each chunk is its
-# own short transaction, so nothing holds a snapshot open across a scan that reads
-# roughly 10 KB per row -- about a terabyte at production scale.
+# Fingerprints read per transaction while streaming a bootstrap, unless the client
+# asks otherwise ("?chunk="). Each chunk is its own short transaction, so nothing
+# holds a snapshot open across a scan that reads roughly 10 KB per row -- about a
+# terabyte at production scale.
 BOOTSTRAP_CHUNK = 1000
 
 
@@ -125,7 +126,7 @@ async def _last_deleted_id(engine) -> int | None:
 
 async def handle_read_changelog(request: Request) -> Response:
     index_name = request.path_params["index"]
-    generation = int(request.path_params["generation"])
+    generation = request.path_params["generation"]
 
     # A mismatch means the consumer is following a different lineage. Saying so
     # is the point: silently serving this one's data would apply it to the wrong
@@ -250,9 +251,10 @@ async def handle_bootstrap(request: Request) -> Response:
     submissions from then on, so replaying it from 0 builds an index missing every
     fingerprint that already existed.
 
-    Not resumable, and takes no parameters. It runs once per cluster -- one node
-    pays for it and the rest take a peer snapshot of the result -- so an interrupted
-    run just starts over.
+    Not resumable. It runs once per cluster -- one node pays for it and the rest
+    take a peer snapshot of the result -- so an interrupted run just starts over.
+    The one parameter, `chunk`, only tunes how many rows each transaction reads;
+    it cannot change what the stream contains.
 
     Correct without holding a snapshot open, which is the part worth understanding.
     `position` is read first, then the table is scanned in chunks, each its own
@@ -275,12 +277,17 @@ async def handle_bootstrap(request: Request) -> Response:
     pulling a terabyte through the primary's buffer cache as fast as it can.
     """
     index_name = request.path_params["index"]
-    generation = int(request.path_params["generation"])
+    generation = request.path_params["generation"]
     if index_name != INDEX_NAME or generation != GENERATION:
         logger.warning(
             "bootstrap requested for unknown lineage %r/%r", index_name, generation
         )
         return Response(status_code=404)
+
+    # Floored at 1 rather than _int_param's 0: LIMIT 0 reads no rows, which is
+    # indistinguishable from the end of the table -- the stream would end after
+    # the header, a silently empty bootstrap.
+    chunk = max(1, _int_param(request, "chunk", BOOTSTRAP_CHUNK, MAX_ENTRIES))
 
     engine = request.app.state.app_ctx.get_fingerprint_db()
     position = await _current_position(engine)
@@ -289,16 +296,23 @@ async def handle_bootstrap(request: Request) -> Response:
         last_id = 0
         streamed = 0
         while True:
-            rows = await _fingerprints_after(engine, last_id, BOOTSTRAP_CHUNK)
+            rows = await _fingerprints_after(engine, last_id, chunk)
             if not rows:
                 break
+            # One yield per chunk, not per row: a per-row yield is a hundred
+            # million tiny sends at production scale, each paying its own HTTP
+            # chunk framing. Backpressure is unaffected -- its unit was already
+            # the chunk of database work.
+            parts = []
             for fingerprint_id, query in rows:
                 # An all-silence fingerprint extracts to nothing. Sending it would
                 # add a document with no terms, which can never match.
                 if query:
-                    yield encode_change(insert_change(fingerprint_id, query))
+                    parts.append(encode_change(insert_change(fingerprint_id, query)))
                 last_id = fingerprint_id
-            streamed += len(rows)
+            if parts:
+                yield b"".join(parts)
+            streamed += len(parts)
         logger.info(
             "bootstrap streamed %d fingerprints at position %d", streamed, position
         )

--- a/acoustid/future/fpindex/wire.py
+++ b/acoustid/future/fpindex/wire.py
@@ -164,3 +164,27 @@ def meta_response(after: int, limit: int, retry_after_ms: int) -> MetaReadRespon
 
 def encode_meta(response: MetaReadResponse) -> bytes:
     return msgspec.msgpack.encode(response)
+
+
+class BootstrapHeader(msgspec.Struct, rename=_field_name_prefix):
+    """First value in a bootstrap stream.
+
+    `position` is the changelog position the streamed state corresponds to, taken
+    before the first chunk is read. The node applies every change in the stream at
+    this one position and resumes the feed from it.
+    """
+
+    position: int
+
+
+def encode_bootstrap_header(position: int) -> bytes:
+    return msgspec.msgpack.encode(BootstrapHeader(position=position))
+
+
+def encode_change(change: Change) -> bytes:
+    """One value in the bootstrap stream, framed only by msgpack itself.
+
+    msgpack values are self-delimiting, so a reader decodes them one after another
+    off the socket without a length prefix or separator.
+    """
+    return msgspec.msgpack.encode(change)

--- a/acoustid/future/fpindex/wire.py
+++ b/acoustid/future/fpindex/wire.py
@@ -181,10 +181,15 @@ def encode_bootstrap_header(position: int) -> bytes:
     return msgspec.msgpack.encode(BootstrapHeader(position=position))
 
 
-def encode_change(change: Change) -> bytes:
-    """One value in the bootstrap stream, framed only by msgpack itself.
+def encode_bootstrap_chunk(changes: Sequence[Change]) -> bytes:
+    """One value in the bootstrap stream: a msgpack array of changes.
 
-    msgpack values are self-delimiting, so a reader decodes them one after another
-    off the socket without a length prefix or separator.
+    msgpack values are self-delimiting, so a reader decodes arrays one after
+    another off the socket without a length prefix or separator.
+
+    An empty array is the terminator, and never appears anywhere else. That puts
+    completion in the msgpack layer itself: a reader that hits end-of-stream
+    without having seen it knows the bootstrap died mid-scan, rather than having
+    to trust HTTP chunked-encoding termination to say so.
     """
-    return msgspec.msgpack.encode(change)
+    return msgspec.msgpack.encode(list(changes))

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -499,13 +499,22 @@ def _decode_stream(payload: bytes):
 BOOTSTRAP = f"/_bootstrap/{INDEX_NAME}/{GENERATION}"
 
 
+def _decode_bootstrap(payload: bytes):
+    """Split a bootstrap stream into (header, changes), checking the framing:
+    arrays of changes, and the empty-array terminator exactly once, at the end."""
+    values = _decode_stream(payload)
+    header, chunks = values[0], values[1:]
+    assert chunks and chunks[-1] == [], "stream must end with the terminator"
+    assert all(chunks[:-1]), "an empty array mid-stream would falsely terminate"
+    return header, [change for chunk in chunks[:-1] for change in chunk]
+
+
 def test_bootstrap_streams_the_whole_corpus(client: TestClient, changelog):
     """What the changelog structurally cannot serve: fingerprints that existed
     before the log did."""
     ids = [_add_fingerprint(changelog, seed) for seed in range(3)]
 
-    values = _decode_stream(client.get(BOOTSTRAP).content)
-    header, changes = values[0], values[1:]
+    header, changes = _decode_bootstrap(client.get(BOOTSTRAP).content)
 
     assert header["p"] == _positions(changelog)[-1]
     assert [c["i"]["i"] for c in changes] == ids
@@ -523,25 +532,45 @@ def test_bootstrap_skips_fingerprints_that_extract_to_nothing(
         conn.commit()
     good = _add_fingerprint(changelog, 7)
 
-    values = _decode_stream(client.get(BOOTSTRAP).content)
-    assert [c["i"]["i"] for c in values[1:]] == [good]
+    _, changes = _decode_bootstrap(client.get(BOOTSTRAP).content)
+    assert [c["i"]["i"] for c in changes] == [good]
+
+    # With one row per chunk, the silence row makes an entire chunk extract to
+    # nothing. It must vanish from the wire, not appear as an empty array the
+    # reader would take for the terminator -- _decode_bootstrap checks that.
+    _, changes = _decode_bootstrap(client.get(BOOTSTRAP, params={"chunk": 1}).content)
+    assert [c["i"]["i"] for c in changes] == [good]
+
+
+def test_bootstrap_of_nothing_is_a_header_and_a_terminator(
+    client: TestClient, changelog
+):
+    """An empty corpus still ends with the terminator, so the reader gets a
+    positive completion signal rather than a bare end-of-stream."""
+    header, changes = _decode_bootstrap(client.get(BOOTSTRAP).content)
+    assert header["p"] == 0
+    assert changes == []
 
 
 def test_bootstrap_rejects_an_unknown_lineage(client: TestClient):
     assert client.get(f"/_bootstrap/other/{GENERATION}").status_code == 404
 
 
-def test_bootstrap_chunk_only_tunes_transaction_size(client: TestClient, changelog):
-    """`chunk` changes how many rows each transaction reads, never what the
-    stream contains. And 0 is clamped to 1 rather than honoured: LIMIT 0 looks
-    exactly like the end of the table, which would end the stream after the
-    header -- a silently empty bootstrap."""
+def test_bootstrap_chunk_only_tunes_framing(client: TestClient, changelog):
+    """`chunk` changes how many rows each transaction reads and how the arrays
+    are cut, never which changes are streamed. And 0 is clamped to 1 rather
+    than honoured: LIMIT 0 looks exactly like the end of the table, which would
+    end the stream after the header -- a silently empty bootstrap."""
     for seed in range(3):
         _add_fingerprint(changelog, seed)
 
-    whole = client.get(BOOTSTRAP).content
-    assert client.get(BOOTSTRAP, params={"chunk": 1}).content == whole
-    assert client.get(BOOTSTRAP, params={"chunk": 0}).content == whole
+    whole = _decode_bootstrap(client.get(BOOTSTRAP).content)
+    assert (
+        _decode_bootstrap(client.get(BOOTSTRAP, params={"chunk": 1}).content) == whole
+    )
+    assert (
+        _decode_bootstrap(client.get(BOOTSTRAP, params={"chunk": 0}).content) == whole
+    )
 
 
 def test_a_fingerprint_inserted_mid_scan_is_covered_by_the_changelog(
@@ -560,7 +589,9 @@ def test_a_fingerprint_inserted_mid_scan_is_covered_by_the_changelog(
     # Arrives after the position was captured.
     during = _add_fingerprint(changelog, 99)
 
-    streamed = [c["i"]["i"] for c in _decode_stream(client.get(BOOTSTRAP).content)[1:]]
+    streamed = [
+        c["i"]["i"] for c in _decode_bootstrap(client.get(BOOTSTRAP).content)[1]
+    ]
     tail = [
         e["c"]["i"]["i"]
         for e in msgspec.msgpack.decode(

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -531,6 +531,19 @@ def test_bootstrap_rejects_an_unknown_lineage(client: TestClient):
     assert client.get(f"/_bootstrap/other/{GENERATION}").status_code == 404
 
 
+def test_bootstrap_chunk_only_tunes_transaction_size(client: TestClient, changelog):
+    """`chunk` changes how many rows each transaction reads, never what the
+    stream contains. And 0 is clamped to 1 rather than honoured: LIMIT 0 looks
+    exactly like the end of the table, which would end the stream after the
+    header -- a silently empty bootstrap."""
+    for seed in range(3):
+        _add_fingerprint(changelog, seed)
+
+    whole = client.get(BOOTSTRAP).content
+    assert client.get(BOOTSTRAP, params={"chunk": 1}).content == whole
+    assert client.get(BOOTSTRAP, params={"chunk": 0}).content == whole
+
+
 def test_a_fingerprint_inserted_mid_scan_is_covered_by_the_changelog(
     client: TestClient, changelog
 ):

--- a/tests/future/fpindex/test_feed.py
+++ b/tests/future/fpindex/test_feed.py
@@ -470,3 +470,92 @@ def test_a_newline_in_the_index_name_cannot_forge_a_log_line(
     message = caplog.records[-1].getMessage()
     assert "\n" not in message, message
     assert "\\n" in message, message
+
+
+# --- bootstrap ---------------------------------------------------------------
+
+
+def _decode_stream(payload: bytes):
+    """Pull successive msgpack values off the stream, as the Zig client does."""
+    decoder = msgspec.msgpack.Decoder()
+    out = []
+    view = memoryview(payload)
+    offset = 0
+    while offset < len(view):
+        # msgspec has no incremental reader, so find each value's end by growing
+        # the slice until it decodes -- fine for test-sized payloads.
+        for end in range(offset + 1, len(view) + 1):
+            try:
+                out.append(decoder.decode(view[offset:end]))
+            except msgspec.DecodeError:
+                continue
+            offset = end
+            break
+        else:
+            raise AssertionError(f"undecodable tail at {offset}")
+    return out
+
+
+BOOTSTRAP = f"/_bootstrap/{INDEX_NAME}/{GENERATION}"
+
+
+def test_bootstrap_streams_the_whole_corpus(client: TestClient, changelog):
+    """What the changelog structurally cannot serve: fingerprints that existed
+    before the log did."""
+    ids = [_add_fingerprint(changelog, seed) for seed in range(3)]
+
+    values = _decode_stream(client.get(BOOTSTRAP).content)
+    header, changes = values[0], values[1:]
+
+    assert header["p"] == _positions(changelog)[-1]
+    assert [c["i"]["i"] for c in changes] == ids
+    assert all(0 < len(c["i"]["h"]) <= 120 for c in changes)
+
+
+def test_bootstrap_skips_fingerprints_that_extract_to_nothing(
+    client: TestClient, changelog
+):
+    """An all-silence fingerprint yields an empty query array. Streaming it would
+    add a document with no terms, which can never match anything."""
+    silence = [627964279] * 200
+    with changelog.connect() as conn:
+        conn.execute(sql.text(INSERT_FINGERPRINT), {"fingerprint": silence})
+        conn.commit()
+    good = _add_fingerprint(changelog, 7)
+
+    values = _decode_stream(client.get(BOOTSTRAP).content)
+    assert [c["i"]["i"] for c in values[1:]] == [good]
+
+
+def test_bootstrap_rejects_an_unknown_lineage(client: TestClient):
+    assert client.get(f"/_bootstrap/other/{GENERATION}").status_code == 404
+
+
+def test_a_fingerprint_inserted_mid_scan_is_covered_by_the_changelog(
+    client: TestClient, changelog
+):
+    """The correctness argument for chunking, exercised rather than asserted.
+
+    A row that appears after `position` was read may or may not land in a chunk,
+    depending on where its id falls. Either way the node ends up with it: it is in
+    the stream, or in the changelog above `position`, or both. What must never
+    happen is neither.
+    """
+    before = [_add_fingerprint(changelog, seed) for seed in range(2)]
+    position = _positions(changelog)[-1]
+
+    # Arrives after the position was captured.
+    during = _add_fingerprint(changelog, 99)
+
+    streamed = [c["i"]["i"] for c in _decode_stream(client.get(BOOTSTRAP).content)[1:]]
+    tail = [
+        e["c"]["i"]["i"]
+        for e in msgspec.msgpack.decode(
+            client.get(FEED, params={"after": position}).content
+        )["e"]
+    ]
+
+    for fingerprint_id in before + [during]:
+        assert fingerprint_id in streamed or fingerprint_id in tail, fingerprint_id
+    # And specifically: the late arrival is recoverable from the feed alone.
+    assert during in tail


### PR DESCRIPTION
    GET /_bootstrap/{index}/{generation}

The initial fill, which the changelog structurally cannot serve: it starts at the
migration and only records submissions from then on, so a node replaying it from 0
builds an index missing every fingerprint that already existed — and gets told
"caught up" while doing so.

A msgpack header carrying `position`, then one `Change` per fingerprint, framed only
by msgpack being self-delimiting. `Change` is the same type the feed emits, so the
node's existing apply path takes them unchanged and installs them all at that single
position (which is what #149's non-decreasing version rule was for).

## No parameters, not resumable

It runs once per cluster — one node pays for it and the rest take a peer snapshot of
the result — so an interrupted run starts over.

An earlier version took `after_id` and `position` to resume. Dropped, because
resumption has to carry the **original** position back:

```
T0   position = max(changelog.id)
     straggler already holds fingerprint id 50, uncommitted
     pass 1 scans past id 50
T0+δ straggler commits -> changelog id > position  (the lock makes ids commit-ordered)
T1   pass 1 dies at id X
     resume: pass 2 scans X+1.. -> never sees id 50
```

That row is in neither scan, and only replaying from the *original* position
recovers it. A fresh position read at T1 is already above its changelog id and skips
it silently. Passing that value in as a query parameter meant trusting the client
with the one number that must not be wrong, to save it one round trip of bad news it
would get anyway from the feed's 410. Not worth it for an operation that runs once.

## No snapshot transaction, and why that is still correct

`position` is read first, then the table is scanned in chunks of 1000, each its own
transaction:

- a fingerprint that existed when `position` was read is **still there** when its
  chunk runs, because fingerprints are never deleted or updated — so the chunks
  cannot miss it;
- anything inserted *during* the scan has a changelog row above `position`;
- replaying from `position` afterwards covers every gap, and the overlap costs
  nothing because inserts are upserts by document id.

There is a test for that middle case rather than just an argument for it.

**This matters at 100M rows.** Measured here: `acoustid_extract_query` costs
**13.5 µs/row** including detoast, so extraction is only ~22 minutes. But the scan
reads about **10 KB per row — a terabyte** — and a single `REPEATABLE READ` would
hold the xmin horizon for the whole run and block vacuum database-wide.

## Backpressure

Streaming means the next chunk is only read once the client has drained the last, so
a slow node throttles the scan instead of pulling a terabyte through the primary's
buffer cache as fast as it can. Verified rather than assumed: first bytes arrive at
**94 ms of a 244 ms** stream, not after it.

## Volume

Measured **620 bytes per fingerprint** on the wire, so roughly **61 GB at 100M**.
That is the argument for filling one node near the database and letting the existing
peer-snapshot path distribute the built index, rather than streaming this to every
node.

## Tests

`bin/test-stack up | pytest | down`: **219 passed, 1 skipped** (6 new).
`isort`, `black`, `flake8`, `mypy` clean.

Also skips fingerprints that extract to nothing — an all-silence fingerprint yields
an empty query array, and sending it would add a document with no terms that can
never match.

## Not covered

- **The node side does not exist.** Nothing consumes this yet: fpindex needs a
  bootstrap-from-source path that applies the stream into a staging directory and
  installs it atomically. Applying at `position` into a live index and crashing at
  1% leaves a node claiming that position with 1% of the data, resuming *after* it,
  and the missing 99% never arrives. It must also fully checkpoint before install,
  since `swapAndReopen` only sees disk, and must not push this through the oplog,
  which is discarded on swap.
- **`after=0` is deliberately not refused.** A bootstrap against an empty changelog
  legitimately returns position 0, so 0 is a valid resume point and cannot be
  distinguished from a node that never bootstrapped. The completeness property
  belongs on the node — an empty index bootstraps first and never replays from 0 —
  not in a feed-side check. `fpindex_meta` stays for one thing only: what retention
  dropped from the changelog, which is what drives 410 → peer snapshot.
- No authentication, consistent with the rest of the feed.
- Not throttled server-side beyond client backpressure — a fast client can still
  pull a terabyte at full speed.

